### PR TITLE
fix: script not working when used as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add the following script to your project's `package.json` file:
 
 ```json
 "scripts": {
-  "generate-ts-schema": "yarn run @ftrack/ts-schema-generator generate"
+  "generate-ts-schema": "ftrack-ts-schema-generator"
 }
 ```
 
@@ -48,16 +48,18 @@ yarn generate-ts-schema
 
 ### Customizing the output path and filename
 
-To customize the output path and filename, pass them as arguments after `--`:
+To customize the output path and filename, pass them as arguments:
 
 ```
-yarn generate -- ./path/to/output/directory customSchemaFilename.ts
+yarn generate ./path/to/output/directory customSchemaFilename.ts
 ```
 
 or if using the script as a dependency in another project:
 
 ```
-yarn generate-ts-schema -- ./path/to/output/directory customSchemaFilename.ts
+"scripts": {
+  "generate-ts-schema": "ftrack-ts-schema-generator ./path/to/output/directory customSchemaFilename.ts"
+}
 ```
 
 ## Output

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "generate": "node dist/ftrack-ts-schema-generator.js",
-    "build": "esbuild source/index.ts --outfile=dist/ftrack-ts-schema-generator.js --platform=node --format=esm --bundle --packages=external",
+    "build": "esbuild source/index.ts --target=esnext --outfile=dist/ftrack-ts-schema-generator.js --platform=node --format=esm --bundle --packages=external",
     "prepack": "yarn build",
     "test": "tsc && eslint --cache --fix --max-warnings=0 ./source && prettier -c ./source",
     "prepublish": "yarn test"
@@ -25,6 +25,7 @@
   "bugs": {
     "url": "https://github.com/ftrackhq/ftrack-ts-schema-generator/issues"
   },
+  "bin": "./dist/ftrack-ts-schema-generator.js",
   "homepage": "http://ftrack.com",
   "devDependencies": {
     "@types/node": "^18.15.11",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   "bugs": {
     "url": "https://github.com/ftrackhq/ftrack-ts-schema-generator/issues"
   },
-  "bin": "./dist/ftrack-ts-schema-generator.js",
+  "bin": {
+    "ftrack-ts-schema-generator": "./path/to/program"
+  },
   "homepage": "http://ftrack.com",
   "devDependencies": {
     "@types/node": "^18.15.11",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/ftrackhq/ftrack-ts-schema-generator/issues"
   },
   "bin": {
-    "ftrack-ts-schema-generator": "./path/to/program"
+    "ftrack-ts-schema-generator": "./dist/ftrack-ts-schema-generator.js"
   },
   "homepage": "http://ftrack.com",
   "devDependencies": {

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 // :copyright: Copyright (c) 2023 ftrack
 // A node.js script to convert our query_schema to TypeScript types
 // TODO: Change type to module in API
@@ -8,8 +9,6 @@ import type {
 import { Session } from "@ftrack/api";
 import * as fs from "fs";
 import * as path from "path";
-import * as url from "url";
-const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 import prettier from "prettier";
 import { convertSchemaToInterface } from "./convertSchemaToInterface.js";
 
@@ -77,7 +76,7 @@ export async function generate(
   const prettifiedContent = prettier.format(allContent, {
     parser: "typescript",
   });
-  fs.mkdirSync(path.resolve(__dirname, outputPath), { recursive: true });
+  fs.mkdirSync(path.resolve(outputPath), { recursive: true });
   fs.writeFileSync(path.join(outputPath, outputFilename), prettifiedContent);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -247,6 +247,8 @@ __metadata:
     prettier: ^2.8.7
     ts-node: ^10.9.1
     typescript: ^5.0.3
+  bin:
+    ts-schema-generator: ./dist/ftrack-ts-schema-generator.js
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -248,7 +248,7 @@ __metadata:
     ts-node: ^10.9.1
     typescript: ^5.0.3
   bin:
-    ts-schema-generator: ./dist/ftrack-ts-schema-generator.js
+    ftrack-ts-schema-generator: ./dist/ftrack-ts-schema-generator.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Changes

There were some issues with the execution of the script when using it as a dependency. This fixes that.

## Test

Follow the readme to use the script from another project as a dependency.