### PR TITLE
feat: remove optionality of types

### DIFF
--- a/source/convertSchemaToInterface.ts
+++ b/source/convertSchemaToInterface.ts
@@ -144,8 +144,8 @@ function convertPropertiesToTypes(
     if (schema.immutable?.includes(key) || schema.computed?.includes(key)) {
       prefix = `readonly `;
     }
-    // All properties are optional, adds a question mark
-    return `${prefix}${key}?: ${type}`;
+    
+    return `${prefix}${key}: ${type}`;
   });
   return convertedProperties;
 }


### PR DESCRIPTION
<!--
  [For internal use] 
  Copy the task id from the bottom of the sidebar and paste it after FTRACK-

  Resolves FTRACK-

-->

Properties should not be optional here in my opinion. They should instead be optional by wrapping them in a `Partial<T>` inside the API client when querying.

At least for properties like "id" etc that are always there. I assume an entity can't exist inside Ftrack without an ID? Others are possibly required too.

Is there a more intelligent way of seeing which are required, or can you perhaps list all the required properties for me? Then I'll make the PR better.

- [x] I have added automatic tests where applicable
- [x] The PR title is suitable as a release note
- [x] The PR contains a description of what has been changed
- [x] The description contains manual test instructions

## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
