### PR TITLE
feat: strong-type type and object_type names

### DIFF
--- a/source/__snapshots__/default-highway-test.snap
+++ b/source/__snapshots__/default-highway-test.snap
@@ -3,6 +3,8 @@
 // from an instance running version 4.13.8 using server on https://ftrack.example.com
 // Not intended to modify manually
 export interface Dashboard {
+  __entity_type__?: "Dashboard";
+  __permissions?: Record<string, any>;
   created_by?: User;
   created_by_id?: string;
   dashboard_resources?: DashboardResource[];
@@ -10,10 +12,10 @@ export interface Dashboard {
   is_shared_with_everyone?: boolean;
   name?: string;
   widgets?: DashboardWidget[];
-  __entity_type__?: "Dashboard";
-  __permissions?: Record<string, any>;
 }
 export interface Timer {
+  __entity_type__?: "Timer";
+  __permissions?: Record<string, any>;
   comment: string;
   context?: Context;
   context_id?: string;
@@ -22,10 +24,10 @@ export interface Timer {
   start: string;
   user?: User;
   user_id: string;
-  __entity_type__?: "Timer";
-  __permissions?: Record<string, any>;
 }
 export interface StatusChange {
+  __entity_type__?: "StatusChange";
+  __permissions?: Record<string, any>;
   date?: string;
   from_status?: Status;
   from_status_id?: string;
@@ -36,17 +38,20 @@ export interface StatusChange {
   status_id?: string;
   user?: User;
   user_id?: string;
-  __entity_type__?: "StatusChange";
-  __permissions?: Record<string, any>;
 }
 export interface TypedContextStatusRuleGroup
-  extends Omit<StatusRuleGroup, "__entity_type__" | "__permissions"> {
-  object_type?: ObjectType<"TypedContextStatusRuleGroup">;
-  object_type_id: string;
+  extends Omit<
+    StatusRuleGroup,
+    "__entity_type__" | "__permissions" | "object_type"
+  > {
   __entity_type__?: "TypedContextStatusRuleGroup";
   __permissions?: Record<string, any>;
+  object_type?: ObjectTypeFor<"TypedContextStatusRuleGroup">;
+  object_type_id: string;
 }
 export interface CalendarEventResource {
+  __entity_type__?: "CalendarEventResource";
+  __permissions?: Record<string, any>;
   calendar_event?: CalendarEvent;
   calendar_event_id: string;
   created_at?: string;
@@ -55,8 +60,6 @@ export interface CalendarEventResource {
   readonly id: string;
   resource?: Resource;
   resource_id: string;
-  __entity_type__?: "CalendarEventResource";
-  __permissions?: Record<string, any>;
 }
 export interface FileComponent
   extends Omit<Component, "__entity_type__" | "__permissions"> {
@@ -64,36 +67,38 @@ export interface FileComponent
   __permissions?: Record<string, any>;
 }
 export interface State {
+  __entity_type__?: "State";
+  __permissions?: Record<string, any>;
   readonly id: string;
   name?: string;
   short?: string;
-  __entity_type__?: "State";
-  __permissions?: Record<string, any>;
 }
 export interface AssetType {
+  __entity_type__?: "AssetType";
+  __permissions?: Record<string, any>;
   assets?: Asset[];
   component?: string;
   readonly id: string;
   name: string;
   short: string;
-  __entity_type__?: "AssetType";
-  __permissions?: Record<string, any>;
 }
 export interface Group
   extends Omit<Resource, "__entity_type__" | "__permissions"> {
+  __entity_type__?: "Group";
+  __permissions?: Record<string, any>;
   children?: Group[];
   custom_attribute_links?: CustomAttributeLink[];
   custom_attribute_links_from?: CustomAttributeLinkFrom[];
-  readonly link?: BasicLink[];
+  readonly link?: string;
   local: boolean;
   memberships?: Membership[];
   name: string;
   parent?: Group;
   parent_id?: string;
-  __entity_type__?: "Group";
-  __permissions?: Record<string, any>;
 }
 export interface TypedContextLink {
+  __entity_type__?: "TypedContextLink";
+  __permissions?: Record<string, any>;
   from?: TypedContext;
   from_id: string;
   readonly id: string;
@@ -101,11 +106,11 @@ export interface TypedContextLink {
   metadata?: Metadata[];
   to?: TypedContext;
   to_id: string;
-  type?: string;
-  __entity_type__?: "TypedContextLink";
-  __permissions?: Record<string, any>;
+  type?: TypeFor<"TypedContextLink">;
 }
 export interface CalendarEvent {
+  __entity_type__?: "CalendarEvent";
+  __permissions?: Record<string, any>;
   calendar_event_resources?: CalendarEventResource[];
   created_at?: string;
   created_by?: User;
@@ -122,12 +127,12 @@ export interface CalendarEvent {
   project?: Project;
   project_id?: string;
   start: string;
-  type?: Type<"CalendarEvent">;
+  type?: TypeFor<"CalendarEvent">;
   type_id?: string;
-  __entity_type__?: "CalendarEvent";
-  __permissions?: Record<string, any>;
 }
 export interface CustomAttributeLink {
+  __entity_type__?: "CustomAttributeLink";
+  __permissions?: Record<string, any>;
   configuration?: CustomAttributeLinkConfiguration;
   readonly configuration_id: string;
   from_entity_type?: string;
@@ -135,27 +140,25 @@ export interface CustomAttributeLink {
   readonly id: string;
   to_entity_type?: string;
   to_id: string;
-  __entity_type__?: "CustomAttributeLink";
-  __permissions?: Record<string, any>;
 }
 export interface Membership {
+  __entity_type__?: "Membership";
+  __permissions?: Record<string, any>;
   group?: Group;
   group_id: string;
   readonly id: string;
   user?: User;
   user_id: string;
-  __entity_type__?: "Membership";
-  __permissions?: Record<string, any>;
 }
 export interface DashboardWidget {
+  __entity_type__?: "DashboardWidget";
+  __permissions?: Record<string, any>;
   config?: string;
   dashboard?: Dashboard;
   dashboard_id?: string;
   readonly id: string;
   sort?: number;
-  type?: string;
-  __entity_type__?: "DashboardWidget";
-  __permissions?: Record<string, any>;
+  type?: TypeFor<"DashboardWidget">;
 }
 export interface AssetVersionStatusRuleGroup
   extends Omit<StatusRuleGroup, "__entity_type__" | "__permissions"> {
@@ -163,6 +166,8 @@ export interface AssetVersionStatusRuleGroup
   __permissions?: Record<string, any>;
 }
 export interface ReviewSessionObject {
+  __entity_type__?: "ReviewSessionObject";
+  __permissions?: Record<string, any>;
   annotations?: ReviewSessionObjectAnnotation[];
   asset_version?: AssetVersion;
   created_at: string;
@@ -176,10 +181,10 @@ export interface ReviewSessionObject {
   statuses?: ReviewSessionObjectStatus[];
   version: string;
   version_id: string;
-  __entity_type__?: "ReviewSessionObject";
-  __permissions?: Record<string, any>;
 }
 export interface ProjectSchema {
+  __entity_type__?: "ProjectSchema";
+  __permissions?: Record<string, any>;
   asset_version_workflow_schema?: WorkflowSchema;
   asset_version_workflow_schema_id?: string;
   readonly id: string;
@@ -192,36 +197,36 @@ export interface ProjectSchema {
   task_workflow_schema?: WorkflowSchema;
   task_workflow_schema_id?: string;
   task_workflow_schema_overrides?: ProjectSchemaOverride[];
-  __entity_type__?: "ProjectSchema";
-  __permissions?: Record<string, any>;
 }
 export interface Appointment {
+  __entity_type__?: "Appointment";
+  __permissions?: Record<string, any>;
   context?: Context;
   context_id: string;
   readonly id: string;
   resource?: Resource;
   resource_id: string;
-  type: string;
-  __entity_type__?: "Appointment";
-  __permissions?: Record<string, any>;
+  type: TypeFor<"Appointment">;
 }
 export interface TaskTypeSchema {
+  __entity_type__?: "TaskTypeSchema";
+  __permissions?: Record<string, any>;
   readonly id: string;
   name?: string;
   types?: Type[];
-  __entity_type__?: "TaskTypeSchema";
-  __permissions?: Record<string, any>;
 }
 export interface ReviewSessionFolder {
+  __entity_type__?: "ReviewSessionFolder";
+  __permissions?: Record<string, any>;
   readonly id: string;
   name: string;
   project?: Project;
   project_id?: string;
   review_sessions?: ReviewSession[];
-  __entity_type__?: "ReviewSessionFolder";
-  __permissions?: Record<string, any>;
 }
 export interface CustomAttributeLinkFrom {
+  __entity_type__?: "CustomAttributeLinkFrom";
+  __permissions?: Record<string, any>;
   configuration?: CustomAttributeLinkConfiguration;
   readonly configuration_id: string;
   from_entity_type?: string;
@@ -229,34 +234,34 @@ export interface CustomAttributeLinkFrom {
   readonly id: string;
   to_entity_type?: string;
   to_id: string;
-  __entity_type__?: "CustomAttributeLinkFrom";
-  __permissions?: Record<string, any>;
 }
 export interface Location {
+  __entity_type__?: "Location";
+  __permissions?: Record<string, any>;
   description?: string;
   readonly id: string;
   label?: string;
   location_components?: ComponentLocation[];
   name: string;
-  __entity_type__?: "Location";
-  __permissions?: Record<string, any>;
 }
 export interface CustomAttributeGroup {
+  __entity_type__?: "CustomAttributeGroup";
+  __permissions?: Record<string, any>;
   custom_attribute_configurations?: CustomAttributeConfiguration[];
   readonly id: string;
   name?: string;
-  __entity_type__?: "CustomAttributeGroup";
-  __permissions?: Record<string, any>;
 }
 export interface CustomAttributeValue {
+  __entity_type__?: "CustomAttributeValue";
+  __permissions?: Record<string, any>;
   configuration?: CustomAttributeConfiguration;
   readonly configuration_id: string;
   readonly entity_id: string;
   value?: string | number | boolean | string[];
-  __entity_type__?: "CustomAttributeValue";
-  __permissions?: Record<string, any>;
 }
 export interface UserSecurityRole {
+  __entity_type__?: "UserSecurityRole";
+  __permissions?: Record<string, any>;
   readonly id: string;
   is_all_open_projects?: boolean;
   is_all_projects?: boolean;
@@ -265,18 +270,18 @@ export interface UserSecurityRole {
   user?: User;
   user_id?: string;
   user_security_role_projects?: UserSecurityRoleProject[];
-  __entity_type__?: "UserSecurityRole";
-  __permissions?: Record<string, any>;
 }
 export interface DashboardResource {
+  __entity_type__?: "DashboardResource";
+  __permissions?: Record<string, any>;
   dashboard?: Dashboard;
   readonly dashboard_id: string;
   resource?: Resource;
   readonly resource_id: string;
-  __entity_type__?: "DashboardResource";
-  __permissions?: Record<string, any>;
 }
 export interface Component {
+  __entity_type__?: "Component";
+  __permissions?: Record<string, any>;
   component_locations?: ComponentLocation[];
   container?: ContainerComponent;
   container_id?: string;
@@ -290,38 +295,41 @@ export interface Component {
   system_type: string;
   version?: AssetVersion;
   version_id?: string;
-  __entity_type__?: "Component";
-  __permissions?: Record<string, any>;
 }
 export interface NoteAnnotationComponent
   extends Omit<NoteComponent, "__entity_type__" | "__permissions"> {
-  data?: object;
   __entity_type__?: "NoteAnnotationComponent";
   __permissions?: Record<string, any>;
+  data?: object;
 }
 export interface SequenceComponent
   extends Omit<ContainerComponent, "__entity_type__" | "__permissions"> {
-  padding: number;
   __entity_type__?: "SequenceComponent";
   __permissions?: Record<string, any>;
+  padding: number;
 }
 export interface Collaborator
   extends Omit<BaseUser, "__entity_type__" | "__permissions"> {
-  created_from_shared_url?: string;
   __entity_type__?: "Collaborator";
   __permissions?: Record<string, any>;
+  created_from_shared_url?: string;
 }
 export interface CustomAttributeConfiguration
-  extends Omit<CustomConfigurationBase, "__entity_type__" | "__permissions"> {
-  default?: string | number | boolean | string[];
-  is_hierarchical?: boolean;
-  type?: CustomAttributeType;
-  type_id?: string;
-  values?: CustomAttributeValue[];
+  extends Omit<
+    CustomConfigurationBase,
+    "__entity_type__" | "__permissions" | "type" | "object_type"
+  > {
   __entity_type__?: "CustomAttributeConfiguration";
   __permissions?: Record<string, any>;
+  default?: string | number | boolean | string[];
+  is_hierarchical?: boolean;
+  type?: TypeFor<"CustomAttributeConfiguration">;
+  type_id?: string;
+  values?: CustomAttributeValue[];
 }
 export interface Status {
+  __entity_type__?: "Status";
+  __permissions?: Record<string, any>;
   color?: string;
   readonly id: string;
   is_active: boolean;
@@ -329,16 +337,16 @@ export interface Status {
   sort?: number;
   state?: State;
   tasks?: Task[];
-  __entity_type__?: "Status";
-  __permissions?: Record<string, any>;
 }
 export interface Scope {
-  readonly id: string;
-  name: string;
   __entity_type__?: "Scope";
   __permissions?: Record<string, any>;
+  readonly id: string;
+  name: string;
 }
 export interface StatusRuleGroup {
+  __entity_type__?: "StatusRuleGroup";
+  __permissions?: Record<string, any>;
   entity_type: string;
   readonly id: string;
   role?: SecurityRole;
@@ -348,14 +356,18 @@ export interface StatusRuleGroup {
   status?: Status;
   status_id: string;
   status_rules?: StatusRule[];
-  __entity_type__?: "StatusRuleGroup";
-  __permissions?: Record<string, any>;
 }
 export interface TypedContextForSubtype<K extends TypedContextSubtype>
   extends Omit<
     Context,
-    "__entity_type__" | "__permissions" | "custom_attributes"
+    | "__entity_type__"
+    | "__permissions"
+    | "custom_attributes"
+    | "type"
+    | "object_type"
   > {
+  __entity_type__?: K;
+  __permissions?: Record<string, any>;
   ancestors?: TypedContext[];
   bid: number;
   readonly bid_time_logged_difference?: number;
@@ -365,7 +377,7 @@ export interface TypedContextForSubtype<K extends TypedContextSubtype>
   incoming_links?: TypedContextLink[];
   lists?: TypedContextList[];
   metadata?: Metadata[];
-  object_type?: ObjectType<K>;
+  object_type?: ObjectTypeFor<K>;
   object_type_id: string;
   outgoing_links?: TypedContextLink[];
   priority?: Priority;
@@ -379,23 +391,23 @@ export interface TypedContextForSubtype<K extends TypedContextSubtype>
   status_id: string;
   readonly thumbnail_source_id?: string;
   readonly time_logged?: number;
-  type?: Type<K>;
+  type?: TypeFor<K>;
   type_id: string;
-  __entity_type__?: K;
-  __permissions?: Record<string, any>;
 }
 export interface Manager {
+  __entity_type__?: "Manager";
+  __permissions?: Record<string, any>;
   context?: Context;
   context_id?: string;
   readonly id: string;
-  type?: ManagerType;
+  type?: TypeFor<"Manager">;
   type_id?: string;
   user?: User;
   user_id?: string;
-  __entity_type__?: "Manager";
-  __permissions?: Record<string, any>;
 }
 export interface CustomConfigurationBase {
+  __entity_type__?: "CustomConfigurationBase";
+  __permissions?: Record<string, any>;
   config: string;
   core: boolean;
   entity_type?: string;
@@ -404,26 +416,26 @@ export interface CustomConfigurationBase {
   readonly id: string;
   key?: string;
   label?: string;
-  object_type?: ObjectType<"CustomConfigurationBase">;
+  object_type?: ObjectTypeFor<"CustomConfigurationBase">;
   object_type_id?: string;
   project_id?: string;
   read_security_roles?: SecurityRole[];
   sort?: number;
   write_security_roles?: SecurityRole[];
-  __entity_type__?: "CustomConfigurationBase";
-  __permissions?: Record<string, any>;
 }
 export interface AssetVersionLink {
+  __entity_type__?: "AssetVersionLink";
+  __permissions?: Record<string, any>;
   from?: AssetVersion;
   from_id: string;
   readonly id: string;
   metadata?: Metadata[];
   to?: AssetVersion;
   to_id: string;
-  __entity_type__?: "AssetVersionLink";
-  __permissions?: Record<string, any>;
 }
 export interface ReviewSessionObjectAnnotation {
+  __entity_type__?: "ReviewSessionObjectAnnotation";
+  __permissions?: Record<string, any>;
   created_at: string;
   data?: string;
   frame_number: number;
@@ -431,48 +443,51 @@ export interface ReviewSessionObjectAnnotation {
   review_session_object?: ReviewSessionObject;
   review_session_object_id?: string;
   updated_at?: string;
-  __entity_type__?: "ReviewSessionObjectAnnotation";
-  __permissions?: Record<string, any>;
 }
 export interface TypedContextList
   extends Omit<
     List,
     "__entity_type__" | "__permissions" | "custom_attributes"
   > {
-  items?: Task[];
   __entity_type__?: "TypedContextList";
   __permissions?: Record<string, any>;
+  items?: Task[];
 }
 export interface NoteLabelLink {
+  __entity_type__?: "NoteLabelLink";
+  __permissions?: Record<string, any>;
   label?: NoteLabel;
   readonly label_id: string;
   note?: Note;
   readonly note_id: string;
-  __entity_type__?: "NoteLabelLink";
-  __permissions?: Record<string, any>;
 }
 export interface TypedContextStatusChange
   extends Omit<StatusChange, "__entity_type__" | "__permissions"> {
-  parent?: TypedContext;
   __entity_type__?: "TypedContextStatusChange";
   __permissions?: Record<string, any>;
+  parent?: TypedContext;
 }
 export interface CustomAttributeLinkConfiguration
-  extends Omit<CustomConfigurationBase, "__entity_type__" | "__permissions"> {
+  extends Omit<
+    CustomConfigurationBase,
+    "__entity_type__" | "__permissions" | "object_type"
+  > {
+  __entity_type__?: "CustomAttributeLinkConfiguration";
+  __permissions?: Record<string, any>;
   readonly entity_type_to: string;
   readonly object_type_id_to?: string;
   object_type_to?: ObjectType;
   one_to_one?: boolean;
-  __entity_type__?: "CustomAttributeLinkConfiguration";
-  __permissions?: Record<string, any>;
 }
 export interface ContainerComponent
   extends Omit<Component, "__entity_type__" | "__permissions"> {
-  members?: Component[];
   __entity_type__?: "ContainerComponent";
   __permissions?: Record<string, any>;
+  members?: Component[];
 }
 export interface AssetVersion {
+  __entity_type__?: "AssetVersion";
+  __permissions?: Record<string, any>;
   asset?: Asset;
   asset_id?: string;
   comment?: string;
@@ -485,7 +500,7 @@ export interface AssetVersion {
   incoming_links?: AssetVersionLink[];
   readonly is_latest_version?: boolean;
   is_published: boolean;
-  readonly link?: BasicLink[];
+  readonly link?: string;
   lists?: AssetVersionList[];
   metadata?: Metadata[];
   notes?: Note[];
@@ -505,25 +520,25 @@ export interface AssetVersion {
   user_id?: string;
   uses_versions?: AssetVersion[];
   version?: number;
-  __entity_type__?: "AssetVersion";
-  __permissions?: Record<string, any>;
 }
 export interface SecurityRole {
-  readonly id: string;
-  name?: string;
-  type?: string;
-  user_security_roles?: UserSecurityRole[];
   __entity_type__?: "SecurityRole";
   __permissions?: Record<string, any>;
+  readonly id: string;
+  name?: string;
+  type?: TypeFor<"SecurityRole">;
+  user_security_roles?: UserSecurityRole[];
 }
 export interface UserApplicationState {
+  __entity_type__?: "UserApplicationState";
+  __permissions?: Record<string, any>;
   readonly key: string;
   readonly user_id: string;
   value: string;
-  __entity_type__?: "UserApplicationState";
-  __permissions?: Record<string, any>;
 }
 export interface ReviewSessionInvitee {
+  __entity_type__?: "ReviewSessionInvitee";
+  __permissions?: Record<string, any>;
   created_at: string;
   created_by?: User;
   created_by_id: string;
@@ -537,10 +552,10 @@ export interface ReviewSessionInvitee {
   review_session?: ReviewSession;
   review_session_id: string;
   statuses?: ReviewSessionObjectStatus[];
-  __entity_type__?: "ReviewSessionInvitee";
-  __permissions?: Record<string, any>;
 }
 export interface Note {
+  __entity_type__?: "Note";
+  __permissions?: Record<string, any>;
   author?: BaseUser;
   category?: NoteCategory;
   category_id?: string;
@@ -565,10 +580,10 @@ export interface Note {
   replies?: Note[];
   thread_activity?: string;
   user_id: string;
-  __entity_type__?: "Note";
-  __permissions?: Record<string, any>;
 }
 export interface Event {
+  __entity_type__?: "Event";
+  __permissions?: Record<string, any>;
   action?: string;
   created_at?: string;
   data?: string;
@@ -581,87 +596,90 @@ export interface Event {
   project_id?: string;
   user?: User;
   user_id?: string;
-  __entity_type__?: "Event";
-  __permissions?: Record<string, any>;
 }
 export interface ListObject {
+  __entity_type__?: "ListObject";
+  __permissions?: Record<string, any>;
   custom_attributes?: Array<TypedContextCustomAttributesMap["ListObject"]>;
   entity_id: string;
   readonly id: string;
   list?: List;
   list_id: string;
-  __entity_type__?: "ListObject";
-  __permissions?: Record<string, any>;
 }
 export interface AssetVersionList
   extends Omit<
     List,
     "__entity_type__" | "__permissions" | "custom_attributes"
   > {
-  items?: AssetVersion[];
   __entity_type__?: "AssetVersionList";
   __permissions?: Record<string, any>;
+  items?: AssetVersion[];
 }
 export interface UserSession {
+  __entity_type__?: "UserSession";
+  __permissions?: Record<string, any>;
   accessed_time?: string;
   creation_time?: string;
   readonly id: string;
   user?: User;
   user_id?: string;
-  __entity_type__?: "UserSession";
-  __permissions?: Record<string, any>;
 }
 export interface EntitySetting {
+  __entity_type__?: "EntitySetting";
+  __permissions?: Record<string, any>;
   readonly group: string;
   readonly name: string;
   readonly parent_id: string;
   parent_type: string;
   value: string;
-  __entity_type__?: "EntitySetting";
-  __permissions?: Record<string, any>;
 }
 export interface Disk {
+  __entity_type__?: "Disk";
+  __permissions?: Record<string, any>;
   readonly id: string;
   name: string;
   projects?: Project[];
   unix?: string;
   windows?: string;
-  __entity_type__?: "Disk";
-  __permissions?: Record<string, any>;
 }
 export interface Job {
+  __entity_type__?: "Job";
+  __permissions?: Record<string, any>;
   created_at?: string;
   data?: string;
   finished_at?: string;
   readonly id: string;
   job_components?: JobComponent[];
   status: string;
-  readonly type: string;
+  readonly type: TypeFor<"Job">;
   user?: User;
   user_id?: string;
-  __entity_type__?: "Job";
-  __permissions?: Record<string, any>;
 }
 export interface TaskTemplateItem {
+  __entity_type__?: "TaskTemplateItem";
+  __permissions?: Record<string, any>;
   readonly id: string;
   task_type?: Type;
   task_type_id: string;
   template?: TaskTemplate;
   template_id: string;
-  __entity_type__?: "TaskTemplateItem";
-  __permissions?: Record<string, any>;
 }
 export interface ProjectSchemaOverride {
+  __entity_type__?: "ProjectSchemaOverride";
+  __permissions?: Record<string, any>;
   readonly id: string;
   project_schema_id?: string;
   type_id?: string;
   workflow_schema?: WorkflowSchema;
   workflow_schema_id?: string;
-  __entity_type__?: "ProjectSchemaOverride";
-  __permissions?: Record<string, any>;
 }
 export interface User
-  extends Omit<BaseUser, "__entity_type__" | "__permissions"> {
+  extends Omit<
+    BaseUser,
+    "__entity_type__" | "__permissions" | "custom_attributes"
+  > {
+  __entity_type__?: "User";
+  __permissions?: Record<string, any>;
   custom_attribute_links?: CustomAttributeLink[];
   custom_attribute_links_from?: CustomAttributeLinkFrom[];
   custom_attributes?: Array<TypedContextCustomAttributesMap["User"]>;
@@ -676,10 +694,10 @@ export interface User
   user_type?: UserType;
   user_type_id?: string;
   username: string;
-  __entity_type__?: "User";
-  __permissions?: Record<string, any>;
 }
 export interface Feed {
+  __entity_type__?: "Feed";
+  __permissions?: Record<string, any>;
   cluster_id?: string;
   created_at?: string;
   distance?: number;
@@ -688,21 +706,21 @@ export interface Feed {
   owner_id?: string;
   relation?: string;
   social_id?: number;
-  __entity_type__?: "Feed";
-  __permissions?: Record<string, any>;
 }
 export interface BaseUser
   extends Omit<Resource, "__entity_type__" | "__permissions"> {
+  __entity_type__?: "BaseUser";
+  __permissions?: Record<string, any>;
   email?: string;
   first_name?: string;
   last_name?: string;
   thumbnail?: Component;
   thumbnail_id?: string;
   readonly thumbnail_url?: object;
-  __entity_type__?: "BaseUser";
-  __permissions?: Record<string, any>;
 }
 export interface ReviewSession {
+  __entity_type__?: "ReviewSession";
+  __permissions?: Record<string, any>;
   availability?: string;
   created_at: string;
   created_by?: User;
@@ -727,74 +745,74 @@ export interface ReviewSession {
   readonly thumbnail_id?: string;
   thumbnail_source_id?: string;
   readonly thumbnail_url?: object;
-  __entity_type__?: "ReviewSession";
-  __permissions?: Record<string, any>;
 }
 export interface UserView {
+  __entity_type__?: "UserView";
+  __permissions?: Record<string, any>;
   global?: boolean;
   readonly id: string;
   name?: string;
   shared_with?: Resource[];
   user?: User;
   user_id?: string;
-  __entity_type__?: "UserView";
-  __permissions?: Record<string, any>;
 }
 export interface Metadata {
+  __entity_type__?: "Metadata";
+  __permissions?: Record<string, any>;
   readonly key: string;
   readonly parent_id: string;
   parent_type: string;
   value: string;
-  __entity_type__?: "Metadata";
-  __permissions?: Record<string, any>;
 }
 export interface NoteCategory
   extends Omit<NoteLabel, "__entity_type__" | "__permissions"> {
   __entity_type__?: "NoteCategory";
   __permissions?: Record<string, any>;
 }
-export interface Type {
+export interface Type<K = string> {
+  __entity_type__?: "Type";
+  __permissions?: Record<string, any>;
   color: string;
   readonly id: string;
   is_billable: boolean;
-  name?: string;
+  name?: K;
   sort: number;
   task_type_schemas?: TaskTypeSchema[];
   tasks?: Task[];
-  __entity_type__?: "Type";
-  __permissions?: Record<string, any>;
 }
 export interface UserType {
-  readonly id: string;
-  readonly name?: string;
   __entity_type__?: "UserType";
   __permissions?: Record<string, any>;
+  readonly id: string;
+  readonly name?: string;
 }
 export interface JobComponent {
+  __entity_type__?: "JobComponent";
+  __permissions?: Record<string, any>;
   component?: Component;
   readonly component_id: string;
   job?: Job;
   readonly job_id: string;
   readonly url?: object;
-  __entity_type__?: "JobComponent";
-  __permissions?: Record<string, any>;
 }
 export interface ListCategory {
+  __entity_type__?: "ListCategory";
+  __permissions?: Record<string, any>;
   readonly id: string;
   lists?: List[];
   name?: string;
-  __entity_type__?: "ListCategory";
-  __permissions?: Record<string, any>;
 }
 export interface WorkflowSchema {
+  __entity_type__?: "WorkflowSchema";
+  __permissions?: Record<string, any>;
   readonly id: string;
   name?: string;
   overrides?: ProjectSchemaOverride[];
   statuses?: Status[];
-  __entity_type__?: "WorkflowSchema";
-  __permissions?: Record<string, any>;
 }
 export interface ReviewSessionObjectStatus {
+  __entity_type__?: "ReviewSessionObjectStatus";
+  __permissions?: Record<string, any>;
   created_at: string;
   readonly id: string;
   invitee?: ReviewSessionInvitee;
@@ -804,10 +822,10 @@ export interface ReviewSessionObjectStatus {
   review_session_object?: ReviewSessionObject;
   review_session_object_id?: string;
   status?: string;
-  __entity_type__?: "ReviewSessionObjectStatus";
-  __permissions?: Record<string, any>;
 }
 export interface Context {
+  __entity_type__?: "Context";
+  __permissions?: Record<string, any>;
   allocations?: Appointment[];
   appointments?: Appointment[];
   assets?: Asset[];
@@ -821,7 +839,7 @@ export interface Context {
   custom_attribute_links_from?: CustomAttributeLinkFrom[];
   custom_attributes?: Array<TypedContextCustomAttributesMap["Context"]>;
   readonly id: string;
-  readonly link?: BasicLink[];
+  readonly link?: string;
   managers?: Manager[];
   name: string;
   notes?: Note[];
@@ -833,34 +851,34 @@ export interface Context {
   thumbnail_id?: string;
   readonly thumbnail_url?: object;
   timelogs?: Timelog[];
-  __entity_type__?: "Context";
-  __permissions?: Record<string, any>;
 }
 export interface Schema {
+  __entity_type__?: "Schema";
+  __permissions?: Record<string, any>;
   readonly id: string;
   object_type_id?: string;
   project_schema_id: string;
   statuses?: SchemaStatus[];
   type_id: string;
   types?: SchemaType[];
-  __entity_type__?: "Schema";
-  __permissions?: Record<string, any>;
 }
 export interface WorkflowSchemaStatus {
-  readonly status_id: string;
-  readonly workflow_schema_id: string;
   __entity_type__?: "WorkflowSchemaStatus";
   __permissions?: Record<string, any>;
+  readonly status_id: string;
+  readonly workflow_schema_id: string;
 }
 export interface SchemaType {
+  __entity_type__?: "SchemaType";
+  __permissions?: Record<string, any>;
   readonly schema_id: string;
   sort?: number;
   task_type?: Type;
   readonly type_id: string;
-  __entity_type__?: "SchemaType";
-  __permissions?: Record<string, any>;
 }
 export interface Asset {
+  __entity_type__?: "Asset";
+  __permissions?: Record<string, any>;
   ancestors?: TypedContext[];
   context_id?: string;
   custom_attribute_links?: CustomAttributeLink[];
@@ -872,13 +890,13 @@ export interface Asset {
   name?: string;
   parent?: Context;
   project_id?: string;
-  type?: AssetType;
+  type?: TypeFor<"Asset">;
   type_id?: string;
   versions?: AssetVersion[];
-  __entity_type__?: "Asset";
-  __permissions?: Record<string, any>;
 }
 export interface SettingComponent {
+  __entity_type__?: "SettingComponent";
+  __permissions?: Record<string, any>;
   component?: Component;
   readonly component_id: string;
   readonly group: string;
@@ -886,19 +904,19 @@ export interface SettingComponent {
   setting?: Setting;
   readonly thumbnail_url?: object;
   readonly url?: object;
-  __entity_type__?: "SettingComponent";
-  __permissions?: Record<string, any>;
 }
 export interface StatusRule {
+  __entity_type__?: "StatusRule";
+  __permissions?: Record<string, any>;
   readonly id: string;
   status?: Status;
   status_id: string;
   status_rule_group?: StatusRuleGroup;
   status_rule_group_id: string;
-  __entity_type__?: "StatusRule";
-  __permissions?: Record<string, any>;
 }
 export interface ComponentLocation {
+  __entity_type__?: "ComponentLocation";
+  __permissions?: Record<string, any>;
   component?: Component;
   component_id?: string;
   readonly id: string;
@@ -906,10 +924,10 @@ export interface ComponentLocation {
   location_id?: string;
   resource_identifier?: string;
   readonly url?: object;
-  __entity_type__?: "ComponentLocation";
-  __permissions?: Record<string, any>;
 }
 export interface ReviewSessionObjectAnnotationComponent {
+  __entity_type__?: "ReviewSessionObjectAnnotationComponent";
+  __permissions?: Record<string, any>;
   component?: Component;
   readonly component_id: string;
   readonly frame_number: string;
@@ -917,19 +935,19 @@ export interface ReviewSessionObjectAnnotationComponent {
   readonly review_session_object_id: string;
   readonly thumbnail_url?: object;
   readonly url?: object;
-  __entity_type__?: "ReviewSessionObjectAnnotationComponent";
-  __permissions?: Record<string, any>;
 }
 export interface CustomAttributeType {
+  __entity_type__?: "CustomAttributeType";
+  __permissions?: Record<string, any>;
   core: boolean;
   custom_attribute_configurations?: CustomAttributeConfiguration[];
   form_config?: string;
   readonly id: string;
   name?: string;
-  __entity_type__?: "CustomAttributeType";
-  __permissions?: Record<string, any>;
 }
 export interface Timelog {
+  __entity_type__?: "Timelog";
+  __permissions?: Record<string, any>;
   comment: string;
   context?: Context;
   context_id?: string;
@@ -940,27 +958,27 @@ export interface Timelog {
   time_zone_offset?: number;
   user?: User;
   user_id?: string;
-  __entity_type__?: "Timelog";
-  __permissions?: Record<string, any>;
 }
 export interface SchemaStatus {
+  __entity_type__?: "SchemaStatus";
+  __permissions?: Record<string, any>;
   readonly schema_id: string;
   sort?: number;
   readonly status_id: string;
   task_status?: Status;
-  __entity_type__?: "SchemaStatus";
-  __permissions?: Record<string, any>;
 }
 export interface UserSecurityRoleProject {
+  __entity_type__?: "UserSecurityRoleProject";
+  __permissions?: Record<string, any>;
   readonly id: string;
   project?: Project;
   project_id?: string;
   user_security_role?: UserSecurityRole;
   user_security_role_id?: string;
-  __entity_type__?: "UserSecurityRoleProject";
-  __permissions?: Record<string, any>;
 }
-export interface ObjectType {
+export interface ObjectType<K = string> {
+  __entity_type__?: "ObjectType";
+  __permissions?: Record<string, any>;
   icon: string;
   readonly id: string;
   is_leaf?: boolean;
@@ -970,18 +988,18 @@ export interface ObjectType {
   is_taskable: boolean;
   is_time_reportable: boolean;
   is_typeable: boolean;
-  name: string;
+  name: K;
   project_schemas?: ProjectSchema[];
   sort: number;
   tasks?: Task[];
-  __entity_type__?: "ObjectType";
-  __permissions?: Record<string, any>;
 }
 export interface Project
   extends Omit<
     Context,
     "__entity_type__" | "__permissions" | "custom_attributes"
   > {
+  __entity_type__?: "Project";
+  __permissions?: Record<string, any>;
   calendar_events?: CalendarEvent[];
   color?: string;
   descendants?: TypedContext[];
@@ -1000,82 +1018,82 @@ export interface Project
   start_date?: string;
   status: string;
   user_security_role_projects?: UserSecurityRoleProject[];
-  __entity_type__?: "Project";
-  __permissions?: Record<string, any>;
 }
 export interface TaskTemplate {
+  __entity_type__?: "TaskTemplate";
+  __permissions?: Record<string, any>;
   readonly id: string;
   items?: TaskTemplateItem[];
   name: string;
   project_schema?: ProjectSchema;
   project_schema_id: string;
-  __entity_type__?: "TaskTemplate";
-  __permissions?: Record<string, any>;
 }
 export interface AssetVersionStatusChange
   extends Omit<StatusChange, "__entity_type__" | "__permissions"> {
-  parent?: AssetVersion;
   __entity_type__?: "AssetVersionStatusChange";
   __permissions?: Record<string, any>;
+  parent?: AssetVersion;
 }
 export interface Setting {
+  __entity_type__?: "Setting";
+  __permissions?: Record<string, any>;
   readonly group: string;
   readonly name: string;
   value?: string;
-  __entity_type__?: "Setting";
-  __permissions?: Record<string, any>;
 }
 export interface ApiKey {
+  __entity_type__?: "ApiKey";
+  __permissions?: Record<string, any>;
   readonly id: string;
   identifier?: string;
   prefix?: string;
   resource_id?: string;
-  __entity_type__?: "ApiKey";
-  __permissions?: Record<string, any>;
 }
 export interface NoteLabel {
+  __entity_type__?: "NoteLabel";
+  __permissions?: Record<string, any>;
   color?: string;
   readonly id: string;
   name?: string;
   sort?: number;
-  __entity_type__?: "NoteLabel";
-  __permissions?: Record<string, any>;
 }
 export interface ManagerType {
-  readonly id: string;
-  name?: string;
   __entity_type__?: "ManagerType";
   __permissions?: Record<string, any>;
+  readonly id: string;
+  name?: string;
 }
 export interface Recipient {
+  __entity_type__?: "Recipient";
+  __permissions?: Record<string, any>;
   note?: Note;
   readonly note_id: string;
   recipient?: Resource;
   readonly resource_id: string;
   text_mentioned?: string;
   user?: User;
-  __entity_type__?: "Recipient";
-  __permissions?: Record<string, any>;
 }
 export interface NoteComponent {
+  __entity_type__?: "NoteComponent";
+  __permissions?: Record<string, any>;
   component?: Component;
   readonly component_id: string;
   note?: Note;
   readonly note_id: string;
   readonly thumbnail_url?: object;
   readonly url?: object;
-  __entity_type__?: "NoteComponent";
-  __permissions?: Record<string, any>;
 }
 export interface ProjectSchemaObjectType {
-  object_type?: ObjectType<"ProjectSchemaObjectType">;
+  __entity_type__?: "ProjectSchemaObjectType";
+  __permissions?: Record<string, any>;
+  object_type?: ObjectTypeFor<"ProjectSchemaObjectType">;
   readonly object_type_id: string;
   project_schema?: ProjectSchema;
   readonly project_schema_id: string;
-  __entity_type__?: "ProjectSchemaObjectType";
-  __permissions?: Record<string, any>;
 }
 export interface List {
+  __entity_type__?: "List";
+  __permissions?: Record<string, any>;
   category?: ListCategory;
   category_id: string;
   custom_attribute_links?: CustomAttributeLink[];
@@ -1090,44 +1108,42 @@ export interface List {
   project_id: string;
   system_type?: string;
   user_id?: string;
-  __entity_type__?: "List";
-  __permissions?: Record<string, any>;
 }
 export interface SplitTaskPart {
+  __entity_type__?: "SplitTaskPart";
+  __permissions?: Record<string, any>;
   end_date: string;
   readonly id: string;
   label?: string;
   start_date: string;
   task?: Task;
   task_id: string;
-  __entity_type__?: "SplitTaskPart";
-  __permissions?: Record<string, any>;
 }
 export interface Resource {
+  __entity_type__?: "Resource";
+  __permissions?: Record<string, any>;
   allocations?: Appointment[];
   appointments?: Appointment[];
   assignments?: Appointment[];
   dashboard_resources?: DashboardResource[];
   readonly id: string;
   resource_type: string;
-  __entity_type__?: "Resource";
-  __permissions?: Record<string, any>;
 }
 export interface TaskTypeSchemaType {
-  readonly task_type_schema_id: string;
-  readonly type_id: string;
   __entity_type__?: "TaskTypeSchemaType";
   __permissions?: Record<string, any>;
+  readonly task_type_schema_id: string;
+  readonly type_id: string;
 }
 export interface Priority {
+  __entity_type__?: "Priority";
+  __permissions?: Record<string, any>;
   color?: string;
   readonly id: string;
   name?: string;
   sort?: number;
   tasks?: Task[];
   value?: number;
-  __entity_type__?: "Priority";
-  __permissions?: Record<string, any>;
 }
 export type Milestone = TypedContextForSubtype<"Milestone">;
 
@@ -1149,142 +1165,142 @@ export type Sequence = TypedContextForSubtype<"Sequence">;
 
 export type Information = TypedContextForSubtype<"Information">;
 export interface ContextCustomAttributeValue {
-  configuration?: CustomAttributeConfiguration;
-  readonly configuration_id: string;
-  readonly entity_id: string;
-  key?: string;
-  value?: string | number | boolean | string[];
   __entity_type__?: "ContextCustomAttributeValue";
   __permissions?: Record<string, any>;
+  configuration?: CustomAttributeConfiguration;
+  readonly configuration_id: string;
+  readonly entity_id: string;
+  key?: string;
+  value?: string | number | boolean | string[];
 }
 export interface AssetVersionCustomAttributeValue {
-  configuration?: CustomAttributeConfiguration;
-  readonly configuration_id: string;
-  readonly entity_id: string;
-  key?: string;
-  value?: string | number | boolean | string[];
   __entity_type__?: "AssetVersionCustomAttributeValue";
   __permissions?: Record<string, any>;
+  configuration?: CustomAttributeConfiguration;
+  readonly configuration_id: string;
+  readonly entity_id: string;
+  key?: string;
+  value?: string | number | boolean | string[];
 }
 export interface ListCustomAttributeValue {
-  configuration?: CustomAttributeConfiguration;
-  readonly configuration_id: string;
-  readonly entity_id: string;
-  key?: string;
-  value?: string | number | boolean | string[];
   __entity_type__?: "ListCustomAttributeValue";
   __permissions?: Record<string, any>;
+  configuration?: CustomAttributeConfiguration;
+  readonly configuration_id: string;
+  readonly entity_id: string;
+  key?: string;
+  value?: string | number | boolean | string[];
 }
 export interface ListObjectCustomAttributeValue {
-  configuration?: CustomAttributeConfiguration;
-  readonly configuration_id: string;
-  readonly entity_id: string;
-  key?: string;
-  value?: string | number | boolean | string[];
   __entity_type__?: "ListObjectCustomAttributeValue";
   __permissions?: Record<string, any>;
+  configuration?: CustomAttributeConfiguration;
+  readonly configuration_id: string;
+  readonly entity_id: string;
+  key?: string;
+  value?: string | number | boolean | string[];
 }
 export interface UserCustomAttributeValue {
-  configuration?: CustomAttributeConfiguration;
-  readonly configuration_id: string;
-  readonly entity_id: string;
-  key?: string;
-  value?: string | number | boolean | string[];
   __entity_type__?: "UserCustomAttributeValue";
   __permissions?: Record<string, any>;
-}
-export interface AssetCustomAttributeValue {
   configuration?: CustomAttributeConfiguration;
   readonly configuration_id: string;
   readonly entity_id: string;
   key?: string;
   value?: string | number | boolean | string[];
+}
+export interface AssetCustomAttributeValue {
   __entity_type__?: "AssetCustomAttributeValue";
   __permissions?: Record<string, any>;
+  configuration?: CustomAttributeConfiguration;
+  readonly configuration_id: string;
+  readonly entity_id: string;
+  key?: string;
+  value?: string | number | boolean | string[];
 }
 export interface ContextCustomAttributeLink
   extends Omit<CustomAttributeLink, "__entity_type__" | "__permissions"> {
-  context?: Context;
   __entity_type__?: "ContextCustomAttributeLink";
   __permissions?: Record<string, any>;
+  context?: Context;
 }
 export interface ContextCustomAttributeLinkFrom
   extends Omit<CustomAttributeLinkFrom, "__entity_type__" | "__permissions"> {
-  context?: Context;
   __entity_type__?: "ContextCustomAttributeLinkFrom";
   __permissions?: Record<string, any>;
+  context?: Context;
 }
 export interface AssetVersionCustomAttributeLink
   extends Omit<CustomAttributeLink, "__entity_type__" | "__permissions"> {
-  asset_version?: AssetVersion;
   __entity_type__?: "AssetVersionCustomAttributeLink";
   __permissions?: Record<string, any>;
+  asset_version?: AssetVersion;
 }
 export interface AssetVersionCustomAttributeLinkFrom
   extends Omit<CustomAttributeLinkFrom, "__entity_type__" | "__permissions"> {
-  asset_version?: AssetVersion;
   __entity_type__?: "AssetVersionCustomAttributeLinkFrom";
   __permissions?: Record<string, any>;
+  asset_version?: AssetVersion;
 }
 export interface ListCustomAttributeLink
   extends Omit<CustomAttributeLink, "__entity_type__" | "__permissions"> {
-  list?: List;
   __entity_type__?: "ListCustomAttributeLink";
   __permissions?: Record<string, any>;
+  list?: List;
 }
 export interface ListCustomAttributeLinkFrom
   extends Omit<CustomAttributeLinkFrom, "__entity_type__" | "__permissions"> {
-  list?: List;
   __entity_type__?: "ListCustomAttributeLinkFrom";
   __permissions?: Record<string, any>;
+  list?: List;
 }
 export interface UserCustomAttributeLink
   extends Omit<CustomAttributeLink, "__entity_type__" | "__permissions"> {
-  user?: User;
   __entity_type__?: "UserCustomAttributeLink";
   __permissions?: Record<string, any>;
+  user?: User;
 }
 export interface UserCustomAttributeLinkFrom
   extends Omit<CustomAttributeLinkFrom, "__entity_type__" | "__permissions"> {
-  user?: User;
   __entity_type__?: "UserCustomAttributeLinkFrom";
   __permissions?: Record<string, any>;
+  user?: User;
 }
 export interface GroupCustomAttributeLink
   extends Omit<CustomAttributeLink, "__entity_type__" | "__permissions"> {
-  group?: Group;
   __entity_type__?: "GroupCustomAttributeLink";
   __permissions?: Record<string, any>;
+  group?: Group;
 }
 export interface GroupCustomAttributeLinkFrom
   extends Omit<CustomAttributeLinkFrom, "__entity_type__" | "__permissions"> {
-  group?: Group;
   __entity_type__?: "GroupCustomAttributeLinkFrom";
   __permissions?: Record<string, any>;
+  group?: Group;
 }
 export interface AssetCustomAttributeLink
   extends Omit<CustomAttributeLink, "__entity_type__" | "__permissions"> {
-  asset?: Asset;
   __entity_type__?: "AssetCustomAttributeLink";
   __permissions?: Record<string, any>;
+  asset?: Asset;
 }
 export interface AssetCustomAttributeLinkFrom
   extends Omit<CustomAttributeLinkFrom, "__entity_type__" | "__permissions"> {
-  asset?: Asset;
   __entity_type__?: "AssetCustomAttributeLinkFrom";
   __permissions?: Record<string, any>;
+  asset?: Asset;
 }
 export interface ComponentCustomAttributeLink
   extends Omit<CustomAttributeLink, "__entity_type__" | "__permissions"> {
-  component?: Component;
   __entity_type__?: "ComponentCustomAttributeLink";
   __permissions?: Record<string, any>;
+  component?: Component;
 }
 export interface ComponentCustomAttributeLinkFrom
   extends Omit<CustomAttributeLinkFrom, "__entity_type__" | "__permissions"> {
-  component?: Component;
   __entity_type__?: "ComponentCustomAttributeLinkFrom";
   __permissions?: Record<string, any>;
+  component?: Component;
 }
 export interface BasicLink {
   id: string;
@@ -2494,6 +2510,10 @@ export function getTypes() {
 export type RuntimeType = ReturnType<typeof getTypes>[number];
 export type RuntimeTypeName = RuntimeType["name"];
 
+interface TypeFor<T extends TypedContextSubtype> extends Omit<Type, "name"> {
+  name: T;
+}
+
 export function getObjectTypes() {
   return [
     {
@@ -2601,6 +2621,11 @@ export function getObjectTypes() {
 
 export type RuntimeObjectType = ReturnType<typeof getObjectTypes>[number];
 export type RuntimeObjectTypeName = RuntimeObjectType["name"];
+
+interface ObjectTypeFor<T extends TypedContextSubtype>
+  extends Omit<Type, "name"> {
+  name: T;
+}
 
 export function getProjectSchemas() {
   return [

--- a/source/__snapshots__/default-highway-test.snap
+++ b/source/__snapshots__/default-highway-test.snap
@@ -103,7 +103,7 @@ export interface TypedContextLink {
   metadata?: Metadata[];
   to?: TypedContext;
   to_id: string;
-  type?: TypeFor<"TypedContextLink">;
+  type?: string;
 }
 export interface CalendarEvent {
   __entity_type__?: "CalendarEvent";
@@ -124,7 +124,7 @@ export interface CalendarEvent {
   project?: Project;
   project_id?: string;
   start: string;
-  type?: TypeFor<"CalendarEvent">;
+  type?: Type;
   type_id?: string;
 }
 export interface CustomAttributeLink {
@@ -155,7 +155,7 @@ export interface DashboardWidget {
   dashboard_id?: string;
   readonly id: string;
   sort?: number;
-  type?: TypeFor<"DashboardWidget">;
+  type?: string;
 }
 export interface AssetVersionStatusRuleGroup
   extends Omit<StatusRuleGroup, "__entity_type__" | "__permissions"> {
@@ -203,7 +203,7 @@ export interface Appointment {
   readonly id: string;
   resource?: Resource;
   resource_id: string;
-  type: TypeFor<"Appointment">;
+  type: string;
 }
 export interface TaskTypeSchema {
   __entity_type__?: "TaskTypeSchema";
@@ -312,15 +312,12 @@ export interface Collaborator
   created_from_shared_url?: string;
 }
 export interface CustomAttributeConfiguration
-  extends Omit<
-    CustomConfigurationBase,
-    "__entity_type__" | "__permissions" | "type"
-  > {
+  extends Omit<CustomConfigurationBase, "__entity_type__" | "__permissions"> {
   __entity_type__?: "CustomAttributeConfiguration";
   __permissions?: Record<string, any>;
   default?: string | number | boolean | string[];
   is_hierarchical?: boolean;
-  type?: TypeFor<"CustomAttributeConfiguration">;
+  type?: CustomAttributeType;
   type_id?: string;
   values?: CustomAttributeValue[];
 }
@@ -357,7 +354,7 @@ export interface StatusRuleGroup {
 export interface TypedContextForSubtype<K extends TypedContextSubtype>
   extends Omit<
     Context,
-    "__entity_type__" | "__permissions" | "custom_attributes" | "type"
+    "__entity_type__" | "__permissions" | "custom_attributes"
   > {
   __entity_type__?: K;
   __permissions?: Record<string, any>;
@@ -393,7 +390,7 @@ export interface Manager {
   context?: Context;
   context_id?: string;
   readonly id: string;
-  type?: TypeFor<"Manager">;
+  type?: ManagerType;
   type_id?: string;
   user?: User;
   user_id?: string;
@@ -516,7 +513,7 @@ export interface SecurityRole {
   __permissions?: Record<string, any>;
   readonly id: string;
   name?: string;
-  type?: TypeFor<"SecurityRole">;
+  type?: string;
   user_security_roles?: UserSecurityRole[];
 }
 export interface UserApplicationState {
@@ -641,7 +638,7 @@ export interface Job {
   readonly id: string;
   job_components?: JobComponent[];
   status: string;
-  readonly type: TypeFor<"Job">;
+  readonly type: string;
   user?: User;
   user_id?: string;
 }
@@ -880,7 +877,7 @@ export interface Asset {
   name?: string;
   parent?: Context;
   project_id?: string;
-  type?: TypeFor<"Asset">;
+  type?: AssetType;
   type_id?: string;
   versions?: AssetVersion[];
 }

--- a/source/__snapshots__/default-highway-test.snap
+++ b/source/__snapshots__/default-highway-test.snap
@@ -41,7 +41,7 @@ export interface StatusChange {
 }
 export interface TypedContextStatusRuleGroup
   extends Omit<StatusRuleGroup, "__entity_type__" | "__permissions"> {
-  object_type?: ObjectType;
+  object_type?: ObjectType<"TypedContextStatusRuleGroup">;
   object_type_id: string;
   __entity_type__?: "TypedContextStatusRuleGroup";
   __permissions?: Record<string, any>;
@@ -122,7 +122,7 @@ export interface CalendarEvent {
   project?: Project;
   project_id?: string;
   start: string;
-  type?: Type;
+  type?: Type<"CalendarEvent">;
   type_id?: string;
   __entity_type__?: "CalendarEvent";
   __permissions?: Record<string, any>;
@@ -365,7 +365,7 @@ export interface TypedContextForSubtype<K extends TypedContextSubtype>
   incoming_links?: TypedContextLink[];
   lists?: TypedContextList[];
   metadata?: Metadata[];
-  object_type?: ObjectType;
+  object_type?: ObjectType<K>;
   object_type_id: string;
   outgoing_links?: TypedContextLink[];
   priority?: Priority;
@@ -379,7 +379,7 @@ export interface TypedContextForSubtype<K extends TypedContextSubtype>
   status_id: string;
   readonly thumbnail_source_id?: string;
   readonly time_logged?: number;
-  type?: Type;
+  type?: Type<K>;
   type_id: string;
   __entity_type__?: K;
   __permissions?: Record<string, any>;
@@ -404,7 +404,7 @@ export interface CustomConfigurationBase {
   readonly id: string;
   key?: string;
   label?: string;
-  object_type?: ObjectType;
+  object_type?: ObjectType<"CustomConfigurationBase">;
   object_type_id?: string;
   project_id?: string;
   read_security_roles?: SecurityRole[];
@@ -1068,7 +1068,7 @@ export interface NoteComponent {
   __permissions?: Record<string, any>;
 }
 export interface ProjectSchemaObjectType {
-  object_type?: ObjectType;
+  object_type?: ObjectType<"ProjectSchemaObjectType">;
   readonly object_type_id: string;
   project_schema?: ProjectSchema;
   readonly project_schema_id: string;

--- a/source/__snapshots__/default-highway-test.snap
+++ b/source/__snapshots__/default-highway-test.snap
@@ -384,7 +384,6 @@ export interface TypedContextForSubtype<K extends TypedContextSubtype>
   type_id: string;
   __entity_type__?: K;
   __permissions?: Record<string, any>;
-  custom_attributes?: Array<TypedContextCustomAttributesMap[K]>;
 }
 export interface Manager {
   context?: Context;
@@ -444,9 +443,6 @@ export interface TypedContextList
   items?: Task[];
   __entity_type__?: "TypedContextList";
   __permissions?: Record<string, any>;
-  custom_attributes?: Array<
-    TypedContextCustomAttributesMap["TypedContextList"]
-  >;
 }
 export interface NoteLabelLink {
   label?: NoteLabel;
@@ -484,6 +480,7 @@ export interface AssetVersion {
   components?: Component[];
   custom_attribute_links?: CustomAttributeLink[];
   custom_attribute_links_from?: CustomAttributeLinkFrom[];
+  custom_attributes?: Array<TypedContextCustomAttributesMap["AssetVersion"]>;
   date?: string;
   readonly id: string;
   incoming_links?: AssetVersionLink[];
@@ -511,7 +508,6 @@ export interface AssetVersion {
   version?: number;
   __entity_type__?: "AssetVersion";
   __permissions?: Record<string, any>;
-  custom_attributes?: Array<TypedContextCustomAttributesMap["AssetVersion"]>;
 }
 export interface SecurityRole {
   readonly id: string;
@@ -590,13 +586,13 @@ export interface Event {
   __permissions?: Record<string, any>;
 }
 export interface ListObject {
+  custom_attributes?: Array<TypedContextCustomAttributesMap["ListObject"]>;
   entity_id: string;
   readonly id: string;
   list?: List;
   list_id: string;
   __entity_type__?: "ListObject";
   __permissions?: Record<string, any>;
-  custom_attributes?: Array<TypedContextCustomAttributesMap["ListObject"]>;
 }
 export interface AssetVersionList
   extends Omit<
@@ -606,9 +602,6 @@ export interface AssetVersionList
   items?: AssetVersion[];
   __entity_type__?: "AssetVersionList";
   __permissions?: Record<string, any>;
-  custom_attributes?: Array<
-    TypedContextCustomAttributesMap["AssetVersionList"]
-  >;
 }
 export interface UserSession {
   accessed_time?: string;
@@ -672,6 +665,7 @@ export interface User
   extends Omit<BaseUser, "__entity_type__" | "__permissions"> {
   custom_attribute_links?: CustomAttributeLink[];
   custom_attribute_links_from?: CustomAttributeLinkFrom[];
+  custom_attributes?: Array<TypedContextCustomAttributesMap["User"]>;
   is_active: boolean;
   is_otp_enabled?: boolean;
   is_totp_enabled?: boolean;
@@ -685,7 +679,6 @@ export interface User
   username: string;
   __entity_type__?: "User";
   __permissions?: Record<string, any>;
-  custom_attributes?: Array<TypedContextCustomAttributesMap["User"]>;
 }
 export interface Feed {
   cluster_id?: string;
@@ -827,6 +820,7 @@ export interface Context {
   readonly created_by_id?: string;
   custom_attribute_links?: CustomAttributeLink[];
   custom_attribute_links_from?: CustomAttributeLinkFrom[];
+  custom_attributes?: Array<TypedContextCustomAttributesMap["Context"]>;
   readonly id: string;
   readonly link?: BasicLink[];
   managers?: Manager[];
@@ -842,7 +836,6 @@ export interface Context {
   timelogs?: Timelog[];
   __entity_type__?: "Context";
   __permissions?: Record<string, any>;
-  custom_attributes?: Array<TypedContextCustomAttributesMap["Context"]>;
 }
 export interface Schema {
   readonly id: string;
@@ -873,6 +866,7 @@ export interface Asset {
   context_id?: string;
   custom_attribute_links?: CustomAttributeLink[];
   custom_attribute_links_from?: CustomAttributeLinkFrom[];
+  custom_attributes?: Array<TypedContextCustomAttributesMap["Asset"]>;
   readonly id: string;
   readonly latest_version?: AssetVersion;
   metadata?: Metadata[];
@@ -884,7 +878,6 @@ export interface Asset {
   versions?: AssetVersion[];
   __entity_type__?: "Asset";
   __permissions?: Record<string, any>;
-  custom_attributes?: Array<TypedContextCustomAttributesMap["Asset"]>;
 }
 export interface SettingComponent {
   component?: Component;
@@ -1010,7 +1003,6 @@ export interface Project
   user_security_role_projects?: UserSecurityRoleProject[];
   __entity_type__?: "Project";
   __permissions?: Record<string, any>;
-  custom_attributes?: Array<TypedContextCustomAttributesMap["Project"]>;
 }
 export interface TaskTemplate {
   readonly id: string;
@@ -1089,6 +1081,7 @@ export interface List {
   category_id: string;
   custom_attribute_links?: CustomAttributeLink[];
   custom_attribute_links_from?: CustomAttributeLinkFrom[];
+  custom_attributes?: Array<TypedContextCustomAttributesMap["List"]>;
   date?: string;
   readonly id: string;
   is_open: boolean;
@@ -1100,7 +1093,6 @@ export interface List {
   user_id?: string;
   __entity_type__?: "List";
   __permissions?: Record<string, any>;
-  custom_attributes?: Array<TypedContextCustomAttributesMap["List"]>;
 }
 export interface SplitTaskPart {
   end_date: string;

--- a/source/__snapshots__/default-highway-test.snap
+++ b/source/__snapshots__/default-highway-test.snap
@@ -2,7 +2,6 @@
 // Generated on 2023-02-01T00:00:00.000Z using schema
 // from an instance running version 4.13.8 using server on https://ftrack.example.com
 // Not intended to modify manually
-
 export interface Dashboard {
   created_by?: User;
   created_by_id?: string;
@@ -1149,7 +1148,6 @@ export type Shot = TypedContextForSubtype<"Shot">;
 export type Sequence = TypedContextForSubtype<"Sequence">;
 
 export type Information = TypedContextForSubtype<"Information">;
-
 export interface ContextCustomAttributeValue {
   configuration?: CustomAttributeConfiguration;
   readonly configuration_id: string;

--- a/source/__snapshots__/default-highway-test.snap
+++ b/source/__snapshots__/default-highway-test.snap
@@ -40,13 +40,10 @@ export interface StatusChange {
   user_id?: string;
 }
 export interface TypedContextStatusRuleGroup
-  extends Omit<
-    StatusRuleGroup,
-    "__entity_type__" | "__permissions" | "object_type"
-  > {
+  extends Omit<StatusRuleGroup, "__entity_type__" | "__permissions"> {
   __entity_type__?: "TypedContextStatusRuleGroup";
   __permissions?: Record<string, any>;
-  object_type?: ObjectTypeFor<"TypedContextStatusRuleGroup">;
+  object_type?: ObjectType;
   object_type_id: string;
 }
 export interface CalendarEventResource {
@@ -317,7 +314,7 @@ export interface Collaborator
 export interface CustomAttributeConfiguration
   extends Omit<
     CustomConfigurationBase,
-    "__entity_type__" | "__permissions" | "type" | "object_type"
+    "__entity_type__" | "__permissions" | "type"
   > {
   __entity_type__?: "CustomAttributeConfiguration";
   __permissions?: Record<string, any>;
@@ -360,11 +357,7 @@ export interface StatusRuleGroup {
 export interface TypedContextForSubtype<K extends TypedContextSubtype>
   extends Omit<
     Context,
-    | "__entity_type__"
-    | "__permissions"
-    | "custom_attributes"
-    | "type"
-    | "object_type"
+    "__entity_type__" | "__permissions" | "custom_attributes" | "type"
   > {
   __entity_type__?: K;
   __permissions?: Record<string, any>;
@@ -416,7 +409,7 @@ export interface CustomConfigurationBase {
   readonly id: string;
   key?: string;
   label?: string;
-  object_type?: ObjectTypeFor<"CustomConfigurationBase">;
+  object_type?: ObjectType;
   object_type_id?: string;
   project_id?: string;
   read_security_roles?: SecurityRole[];
@@ -468,10 +461,7 @@ export interface TypedContextStatusChange
   parent?: TypedContext;
 }
 export interface CustomAttributeLinkConfiguration
-  extends Omit<
-    CustomConfigurationBase,
-    "__entity_type__" | "__permissions" | "object_type"
-  > {
+  extends Omit<CustomConfigurationBase, "__entity_type__" | "__permissions"> {
   __entity_type__?: "CustomAttributeLinkConfiguration";
   __permissions?: Record<string, any>;
   readonly entity_type_to: string;
@@ -769,13 +759,13 @@ export interface NoteCategory
   __entity_type__?: "NoteCategory";
   __permissions?: Record<string, any>;
 }
-export interface Type<K = string> {
+export interface Type {
   __entity_type__?: "Type";
   __permissions?: Record<string, any>;
   color: string;
   readonly id: string;
   is_billable: boolean;
-  name?: K;
+  name?: string;
   sort: number;
   task_type_schemas?: TaskTypeSchema[];
   tasks?: Task[];
@@ -976,7 +966,7 @@ export interface UserSecurityRoleProject {
   user_security_role?: UserSecurityRole;
   user_security_role_id?: string;
 }
-export interface ObjectType<K = string> {
+export interface ObjectType {
   __entity_type__?: "ObjectType";
   __permissions?: Record<string, any>;
   icon: string;
@@ -988,7 +978,7 @@ export interface ObjectType<K = string> {
   is_taskable: boolean;
   is_time_reportable: boolean;
   is_typeable: boolean;
-  name: K;
+  name: string;
   project_schemas?: ProjectSchema[];
   sort: number;
   tasks?: Task[];
@@ -1086,7 +1076,7 @@ export interface NoteComponent {
 export interface ProjectSchemaObjectType {
   __entity_type__?: "ProjectSchemaObjectType";
   __permissions?: Record<string, any>;
-  object_type?: ObjectTypeFor<"ProjectSchemaObjectType">;
+  object_type?: ObjectType;
   readonly object_type_id: string;
   project_schema?: ProjectSchema;
   readonly project_schema_id: string;
@@ -2623,7 +2613,7 @@ export type RuntimeObjectType = ReturnType<typeof getObjectTypes>[number];
 export type RuntimeObjectTypeName = RuntimeObjectType["name"];
 
 interface ObjectTypeFor<T extends TypedContextSubtype>
-  extends Omit<Type, "name"> {
+  extends Omit<ObjectType, "name"> {
   name: T;
 }
 

--- a/source/__snapshots__/schema-has-array-type.snap
+++ b/source/__snapshots__/schema-has-array-type.snap
@@ -7,10 +7,10 @@ export interface TypedContextForSubtype<K extends TypedContextSubtype> {
   __permissions?: Record<string, any>;
 }
 export interface SomeInterfaceName {
-  arrayProperty?: ArrayItem[];
-  mappedArrayProperty?: ArrayItem[];
   __entity_type__?: "SomeInterfaceName";
   __permissions?: Record<string, any>;
+  arrayProperty?: ArrayItem[];
+  mappedArrayProperty?: ArrayItem[];
 }
 export interface ArrayItem {
   __entity_type__?: "ArrayItem";
@@ -76,12 +76,21 @@ export function getTypes() {
 export type RuntimeType = ReturnType<typeof getTypes>[number];
 export type RuntimeTypeName = RuntimeType["name"];
 
+interface TypeFor<T extends TypedContextSubtype> extends Omit<Type, "name"> {
+  name: T;
+}
+
 export function getObjectTypes() {
   return [] as const;
 }
 
 export type RuntimeObjectType = ReturnType<typeof getObjectTypes>[number];
 export type RuntimeObjectTypeName = RuntimeObjectType["name"];
+
+interface ObjectTypeFor<T extends TypedContextSubtype>
+  extends Omit<Type, "name"> {
+  name: T;
+}
 
 export function getProjectSchemas() {
   return [] as const;

--- a/source/__snapshots__/schema-has-array-type.snap
+++ b/source/__snapshots__/schema-has-array-type.snap
@@ -2,7 +2,6 @@
 // Generated on 2023-02-01T00:00:00.000Z using schema
 // from an instance running version 4.13.8 using server on https://ftrack.example.com
 // Not intended to modify manually
-
 export interface TypedContextForSubtype<K extends TypedContextSubtype> {
   __entity_type__?: K;
   __permissions?: Record<string, any>;

--- a/source/__snapshots__/schema-has-array-type.snap
+++ b/source/__snapshots__/schema-has-array-type.snap
@@ -88,7 +88,7 @@ export type RuntimeObjectType = ReturnType<typeof getObjectTypes>[number];
 export type RuntimeObjectTypeName = RuntimeObjectType["name"];
 
 interface ObjectTypeFor<T extends TypedContextSubtype>
-  extends Omit<Type, "name"> {
+  extends Omit<ObjectType, "name"> {
   name: T;
 }
 

--- a/source/__snapshots__/schema-has-base-schema.snap
+++ b/source/__snapshots__/schema-has-base-schema.snap
@@ -2,7 +2,6 @@
 // Generated on 2023-02-01T00:00:00.000Z using schema
 // from an instance running version 4.13.8 using server on https://ftrack.example.com
 // Not intended to modify manually
-
 export interface TypedContextForSubtype<K extends TypedContextSubtype> {
   __entity_type__?: K;
   __permissions?: Record<string, any>;

--- a/source/__snapshots__/schema-has-base-schema.snap
+++ b/source/__snapshots__/schema-has-base-schema.snap
@@ -75,12 +75,21 @@ export function getTypes() {
 export type RuntimeType = ReturnType<typeof getTypes>[number];
 export type RuntimeTypeName = RuntimeType["name"];
 
+interface TypeFor<T extends TypedContextSubtype> extends Omit<Type, "name"> {
+  name: T;
+}
+
 export function getObjectTypes() {
   return [] as const;
 }
 
 export type RuntimeObjectType = ReturnType<typeof getObjectTypes>[number];
 export type RuntimeObjectTypeName = RuntimeObjectType["name"];
+
+interface ObjectTypeFor<T extends TypedContextSubtype>
+  extends Omit<Type, "name"> {
+  name: T;
+}
 
 export function getProjectSchemas() {
   return [] as const;

--- a/source/__snapshots__/schema-has-base-schema.snap
+++ b/source/__snapshots__/schema-has-base-schema.snap
@@ -87,7 +87,7 @@ export type RuntimeObjectType = ReturnType<typeof getObjectTypes>[number];
 export type RuntimeObjectTypeName = RuntimeObjectType["name"];
 
 interface ObjectTypeFor<T extends TypedContextSubtype>
-  extends Omit<Type, "name"> {
+  extends Omit<ObjectType, "name"> {
   name: T;
 }
 

--- a/source/__snapshots__/schema-has-immutable-property.snap
+++ b/source/__snapshots__/schema-has-immutable-property.snap
@@ -81,7 +81,7 @@ export type RuntimeObjectType = ReturnType<typeof getObjectTypes>[number];
 export type RuntimeObjectTypeName = RuntimeObjectType["name"];
 
 interface ObjectTypeFor<T extends TypedContextSubtype>
-  extends Omit<Type, "name"> {
+  extends Omit<ObjectType, "name"> {
   name: T;
 }
 

--- a/source/__snapshots__/schema-has-immutable-property.snap
+++ b/source/__snapshots__/schema-has-immutable-property.snap
@@ -2,7 +2,6 @@
 // Generated on 2023-02-01T00:00:00.000Z using schema
 // from an instance running version 4.13.8 using server on https://ftrack.example.com
 // Not intended to modify manually
-
 export interface TypedContextForSubtype<K extends TypedContextSubtype> {
   __entity_type__?: K;
   __permissions?: Record<string, any>;

--- a/source/__snapshots__/schema-has-immutable-property.snap
+++ b/source/__snapshots__/schema-has-immutable-property.snap
@@ -7,9 +7,9 @@ export interface TypedContextForSubtype<K extends TypedContextSubtype> {
   __permissions?: Record<string, any>;
 }
 export interface SomeInterfaceName {
-  readonly immutableProperty?: string | number | boolean | string[];
   __entity_type__?: "SomeInterfaceName";
   __permissions?: Record<string, any>;
+  readonly immutableProperty?: string | number | boolean | string[];
 }
 export interface BasicLink {
   id: string;
@@ -69,12 +69,21 @@ export function getTypes() {
 export type RuntimeType = ReturnType<typeof getTypes>[number];
 export type RuntimeTypeName = RuntimeType["name"];
 
+interface TypeFor<T extends TypedContextSubtype> extends Omit<Type, "name"> {
+  name: T;
+}
+
 export function getObjectTypes() {
   return [] as const;
 }
 
 export type RuntimeObjectType = ReturnType<typeof getObjectTypes>[number];
 export type RuntimeObjectTypeName = RuntimeObjectType["name"];
+
+interface ObjectTypeFor<T extends TypedContextSubtype>
+  extends Omit<Type, "name"> {
+  name: T;
+}
 
 export function getProjectSchemas() {
   return [] as const;

--- a/source/__snapshots__/schema-has-integer-type.snap
+++ b/source/__snapshots__/schema-has-integer-type.snap
@@ -81,7 +81,7 @@ export type RuntimeObjectType = ReturnType<typeof getObjectTypes>[number];
 export type RuntimeObjectTypeName = RuntimeObjectType["name"];
 
 interface ObjectTypeFor<T extends TypedContextSubtype>
-  extends Omit<Type, "name"> {
+  extends Omit<ObjectType, "name"> {
   name: T;
 }
 

--- a/source/__snapshots__/schema-has-integer-type.snap
+++ b/source/__snapshots__/schema-has-integer-type.snap
@@ -2,7 +2,6 @@
 // Generated on 2023-02-01T00:00:00.000Z using schema
 // from an instance running version 4.13.8 using server on https://ftrack.example.com
 // Not intended to modify manually
-
 export interface TypedContextForSubtype<K extends TypedContextSubtype> {
   __entity_type__?: K;
   __permissions?: Record<string, any>;

--- a/source/__snapshots__/schema-has-integer-type.snap
+++ b/source/__snapshots__/schema-has-integer-type.snap
@@ -7,9 +7,9 @@ export interface TypedContextForSubtype<K extends TypedContextSubtype> {
   __permissions?: Record<string, any>;
 }
 export interface SomeInterfaceName {
-  integerProperty?: number;
   __entity_type__?: "SomeInterfaceName";
   __permissions?: Record<string, any>;
+  integerProperty?: number;
 }
 export interface BasicLink {
   id: string;
@@ -69,12 +69,21 @@ export function getTypes() {
 export type RuntimeType = ReturnType<typeof getTypes>[number];
 export type RuntimeTypeName = RuntimeType["name"];
 
+interface TypeFor<T extends TypedContextSubtype> extends Omit<Type, "name"> {
+  name: T;
+}
+
 export function getObjectTypes() {
   return [] as const;
 }
 
 export type RuntimeObjectType = ReturnType<typeof getObjectTypes>[number];
 export type RuntimeObjectTypeName = RuntimeObjectType["name"];
+
+interface ObjectTypeFor<T extends TypedContextSubtype>
+  extends Omit<Type, "name"> {
+  name: T;
+}
 
 export function getProjectSchemas() {
   return [] as const;

--- a/source/__snapshots__/schema-has-variable-type.snap
+++ b/source/__snapshots__/schema-has-variable-type.snap
@@ -81,7 +81,7 @@ export type RuntimeObjectType = ReturnType<typeof getObjectTypes>[number];
 export type RuntimeObjectTypeName = RuntimeObjectType["name"];
 
 interface ObjectTypeFor<T extends TypedContextSubtype>
-  extends Omit<Type, "name"> {
+  extends Omit<ObjectType, "name"> {
   name: T;
 }
 

--- a/source/__snapshots__/schema-has-variable-type.snap
+++ b/source/__snapshots__/schema-has-variable-type.snap
@@ -2,7 +2,6 @@
 // Generated on 2023-02-01T00:00:00.000Z using schema
 // from an instance running version 4.13.8 using server on https://ftrack.example.com
 // Not intended to modify manually
-
 export interface TypedContextForSubtype<K extends TypedContextSubtype> {
   __entity_type__?: K;
   __permissions?: Record<string, any>;

--- a/source/__snapshots__/schema-has-variable-type.snap
+++ b/source/__snapshots__/schema-has-variable-type.snap
@@ -7,9 +7,9 @@ export interface TypedContextForSubtype<K extends TypedContextSubtype> {
   __permissions?: Record<string, any>;
 }
 export interface SomeInterfaceName {
-  integerProperty?: string | number | boolean | string[];
   __entity_type__?: "SomeInterfaceName";
   __permissions?: Record<string, any>;
+  integerProperty?: string | number | boolean | string[];
 }
 export interface BasicLink {
   id: string;
@@ -69,12 +69,21 @@ export function getTypes() {
 export type RuntimeType = ReturnType<typeof getTypes>[number];
 export type RuntimeTypeName = RuntimeType["name"];
 
+interface TypeFor<T extends TypedContextSubtype> extends Omit<Type, "name"> {
+  name: T;
+}
+
 export function getObjectTypes() {
   return [] as const;
 }
 
 export type RuntimeObjectType = ReturnType<typeof getObjectTypes>[number];
 export type RuntimeObjectTypeName = RuntimeObjectType["name"];
+
+interface ObjectTypeFor<T extends TypedContextSubtype>
+  extends Omit<Type, "name"> {
+  name: T;
+}
 
 export function getProjectSchemas() {
   return [] as const;

--- a/source/__snapshots__/schema-subtype-of-TypedContext.snap
+++ b/source/__snapshots__/schema-subtype-of-TypedContext.snap
@@ -2,7 +2,6 @@
 // Generated on 2023-02-01T00:00:00.000Z using schema
 // from an instance running version 4.13.8 using server on https://ftrack.example.com
 // Not intended to modify manually
-
 export interface TypedContextForSubtype<K extends TypedContextSubtype> {
   __entity_type__?: K;
   __permissions?: Record<string, any>;

--- a/source/__snapshots__/schema-subtype-of-TypedContext.snap
+++ b/source/__snapshots__/schema-subtype-of-TypedContext.snap
@@ -80,7 +80,7 @@ export type RuntimeObjectType = ReturnType<typeof getObjectTypes>[number];
 export type RuntimeObjectTypeName = RuntimeObjectType["name"];
 
 interface ObjectTypeFor<T extends TypedContextSubtype>
-  extends Omit<Type, "name"> {
+  extends Omit<ObjectType, "name"> {
   name: T;
 }
 

--- a/source/__snapshots__/schema-subtype-of-TypedContext.snap
+++ b/source/__snapshots__/schema-subtype-of-TypedContext.snap
@@ -68,12 +68,21 @@ export function getTypes() {
 export type RuntimeType = ReturnType<typeof getTypes>[number];
 export type RuntimeTypeName = RuntimeType["name"];
 
+interface TypeFor<T extends TypedContextSubtype> extends Omit<Type, "name"> {
+  name: T;
+}
+
 export function getObjectTypes() {
   return [] as const;
 }
 
 export type RuntimeObjectType = ReturnType<typeof getObjectTypes>[number];
 export type RuntimeObjectTypeName = RuntimeObjectType["name"];
+
+interface ObjectTypeFor<T extends TypedContextSubtype>
+  extends Omit<Type, "name"> {
+  name: T;
+}
 
 export function getProjectSchemas() {
   return [] as const;

--- a/source/emit.ts
+++ b/source/emit.ts
@@ -215,7 +215,7 @@ export async function emitToString(
     export type RuntimeObjectType = ReturnType<typeof getObjectTypes>[number];
     export type RuntimeObjectTypeName = RuntimeObjectType["name"];
 
-    interface ObjectTypeFor<T extends TypedContextSubtype> extends Omit<Type, "name"> {
+    interface ObjectTypeFor<T extends TypedContextSubtype> extends Omit<ObjectType, "name"> {
       name: T;
     };
 `);

--- a/source/emit.ts
+++ b/source/emit.ts
@@ -128,7 +128,7 @@ export async function emitToString(
   }
 
   const emitter = new TypeScriptEmitter();
-  emitter.appendCode(`
+  emitter.appendBlock(`
     // :copyright: Copyright (c) ${new Date().getFullYear()} ftrack
     // Generated on ${new Date().toISOString()} using schema
     // from an instance running version ${serverVersion} using server on ${serverUrl}
@@ -148,7 +148,7 @@ export async function emitToString(
   BasicLink needs to be added explicitly, as it is not returned by the API.
   Task: 95e02be2-c7ec-11ed-ae64-46416ff77027
   */
-  emitter.appendCode(`
+  emitter.appendBlock(`
     export interface BasicLink {
       id: string;
       type: string;
@@ -157,7 +157,7 @@ export async function emitToString(
   `);
 
   // Add a map of entity types and type for EntityType and a type for EntityData
-  emitter.appendCode(`
+  emitter.appendBlock(`
     export interface EntityTypeMap {
       ${schemas
         .map((s) => s.id)
@@ -174,7 +174,7 @@ export async function emitToString(
 
   emitCustomAttributes(emitter, schemas, customAttributes);
 
-  emitter.appendCode(`
+  emitter.appendBlock(`
     export function getTypes() {
       return [
         ${types.map(
@@ -190,7 +190,7 @@ export async function emitToString(
     export type RuntimeTypeName = RuntimeType["name"];
   `);
 
-  emitter.appendCode(`
+  emitter.appendBlock(`
     export function getObjectTypes() {
       return [
         ${objectTypes.map(
@@ -212,7 +212,7 @@ export async function emitToString(
     export type RuntimeObjectTypeName = RuntimeObjectType["name"];
 `);
 
-  emitter.appendCode(`
+  emitter.appendBlock(`
     export function getProjectSchemas() {
       return [
         ${projectSchemas.map(
@@ -233,7 +233,7 @@ export async function emitToString(
     export type RuntimeProjectSchemaName = RuntimeProjectSchema["name"];
   `);
 
-  emitter.appendCode(`
+  emitter.appendBlock(`
     export function getPriorities() {
       return [
         ${priorities.map(
@@ -251,7 +251,7 @@ export async function emitToString(
     export type RuntimePriorityName = RuntimePriority["name"];
   `);
 
-  emitter.appendCode(`
+  emitter.appendBlock(`
     export function getStatuses() {
       return [
         ${statuses.map(
@@ -331,7 +331,7 @@ function emitTypedContextTypes(
   builder: TypeScriptEmitter,
   schemas: QuerySchemasResponse
 ) {
-  builder.appendCode(`
+  builder.appendBlock(`
     export interface TypedContextSubtypeMap {
       ${schemas
         .filter(

--- a/source/emit.ts
+++ b/source/emit.ts
@@ -188,6 +188,10 @@ export async function emitToString(
 
     export type RuntimeType = ReturnType<typeof getTypes>[number];
     export type RuntimeTypeName = RuntimeType["name"];
+
+    interface TypeFor<T extends TypedContextSubtype> extends Omit<Type, "name"> {
+      name: T;
+    };
   `);
 
   emitter.appendBlock(`
@@ -210,6 +214,10 @@ export async function emitToString(
 
     export type RuntimeObjectType = ReturnType<typeof getObjectTypes>[number];
     export type RuntimeObjectTypeName = RuntimeObjectType["name"];
+
+    interface ObjectTypeFor<T extends TypedContextSubtype> extends Omit<Type, "name"> {
+      name: T;
+    };
 `);
 
   emitter.appendBlock(`

--- a/source/emitCustomAttributes.ts
+++ b/source/emitCustomAttributes.ts
@@ -7,7 +7,7 @@ export function emitCustomAttributes(
   schemas: QuerySchemasResponse,
   customAttributes: CustomAttributeConfiguration[]
 ) {
-  typescriptEmitter.appendCode(`
+  typescriptEmitter.appendBlock(`
     export function getAttributeConfigurations() {
         return [
             ${customAttributes.map(

--- a/source/emitSchema.ts
+++ b/source/emitSchema.ts
@@ -8,7 +8,7 @@ import type {
 } from "@ftrack/api";
 import { type TypeScriptEmitter } from "./typescriptEmitter";
 import { isSchemaTypedContext } from "./utils";
-import { chain, uniqBy } from "lodash-es";
+import { chain } from "lodash-es";
 
 // Add schemas from the schemas folder, to be used for finding extended schemas
 export async function emitSchemaInterface(

--- a/source/emitSchema.ts
+++ b/source/emitSchema.ts
@@ -139,7 +139,6 @@ function getOverriddenSchemaType(schema?: Schema, baseSchema?: Schema|undefined)
       undefined,
     properties: [
       { name: "custom_attributes", typescriptType: `Array<TypedContextCustomAttributesMap[${entityTypeMapKeyName}]>` },
-      { name: "type", typescriptType: `TypeFor<${entityTypeMapKeyName}>` },
     ]
   };
 }

--- a/source/emitSchema.ts
+++ b/source/emitSchema.ts
@@ -8,7 +8,7 @@ import type {
 } from "@ftrack/api";
 import { type TypeScriptEmitter } from "./typescriptEmitter";
 import { isSchemaTypedContext } from "./utils";
-import { chain } from "lodash-es";
+import { chain, uniqBy } from "lodash-es";
 
 // Add schemas from the schemas folder, to be used for finding extended schemas
 export async function emitSchemaInterface(
@@ -16,80 +16,39 @@ export async function emitSchemaInterface(
   schema: Schema,
   allSchemas: QuerySchemasResponse
 ) {
-  const isSchemaSubtypeOfTypedContext = typeof schema?.alias_for === "object" && schema.alias_for.id === "Task";
-  if (isSchemaSubtypeOfTypedContext) {
+  if (isSchemaSubtypeOfTypedContext(schema)) {
     typescriptEmitter.appendBlock(`
       export type ${schema.id} = TypedContextForSubtype<"${schema.id}">;
     `);
     return;
   }
 
-  // Check if the schema extends another schema and get that base schema
-  const baseSchema = getBaseSchema(schema, allSchemas);
+  const baseSchema = isSchemaSubtypeOfTypedContext(schema) ?
+    allSchemas.find(isSchemaTypedContext) :
+    getBaseSchema(schema, allSchemas);
 
-  // Get the typedContext schema, to filter the properties for typedContext subtypes
-  const typedContextSchema = allSchemas.find(isSchemaTypedContext);
+  const overriddenSchemaType = getOverriddenSchemaType(schema, baseSchema);
+  typescriptEmitter.appendBlock(`export interface ${overriddenSchemaType.name ?? schema.id}`);
 
-  const interfaceName = isSchemaTypedContext(schema) ?
-    `TypedContextForSubtype<K extends TypedContextSubtype>` :
-    `${schema.id}`;
-  typescriptEmitter.appendBlock(`export interface ${interfaceName}`);
+  typescriptEmitter.appendBlock(overriddenSchemaType.genericArguments ? 
+    `<${overriddenSchemaType.genericArguments.join(", ")}>` : 
+    "");
     
-  typescriptEmitter.appendInline(getTypeExtensionSuffix(
-    baseSchema,
-    schema
-  ));
+  typescriptEmitter.appendBlock(overriddenSchemaType.extends ? `extends ${overriddenSchemaType.extends}` : "");
 
   typescriptEmitter.appendBlock(`{`);
 
-  // For each property, add a type to the interface
   emitTypeProperties(
     typescriptEmitter,
     schema,
-    baseSchema?.properties,
-    typedContextSchema?.properties
+    baseSchema
   );
-
-  // Entity type and permissions are missing from the source schema, so add them to the interface
-  emitSpecialProperties(typescriptEmitter, schema);
 
   typescriptEmitter.appendBlock(`}`);
 }
 
-function emitSpecialProperties(
-  typescriptEmitter: TypeScriptEmitter,
-  schema: Schema
-) {
-  if (isSchemaTypedContext(schema)) {
-    typescriptEmitter.appendBlock(`__entity_type__?: K;`);
-  } else {
-    typescriptEmitter.appendBlock(`__entity_type__?: "${schema.id}";`);
-  }
-  typescriptEmitter.appendBlock(`__permissions?: Record<string, any>;`);
-}
-
-function getTypeExtensionSuffix(
-  baseSchema: Schema | undefined,
-  schema: Schema
-) {
-  const omitList = ["__entity_type__", "__permissions"];
-  if (baseSchema?.properties && "custom_attributes" in baseSchema.properties) {
-    omitList.push("custom_attributes");
-  }
-
-  const omitString = `"${omitList.join('" | "')}"`;
-
-  const baseSchemaSuffix = baseSchema?.id
-    ? ` extends Omit<${baseSchema.id}, ${omitString}>`
-    : "";
-
-  const typedContextSubtypeSuffix =
-    typeof schema?.alias_for === "object" && schema.alias_for.id === "Task"
-      ? ` extends Omit<TypedContext, ${omitString}>`
-      : "";
-
-  //Both should never be true, but ¯\_(ツ)_/¯
-  return baseSchemaSuffix + typedContextSubtypeSuffix;
+function isSchemaSubtypeOfTypedContext(schema: Schema) {
+  return typeof schema?.alias_for === "object" && schema.alias_for.id === "Task";
 }
 
 //Todo: update when Schema type in API is updated
@@ -107,92 +66,121 @@ function getBaseSchema(schema: Schema, allSchemas: QuerySchemasResponse) {
 function emitTypeProperties(
   typescriptEmitter: TypeScriptEmitter,
   schema: Schema,
-  baseSchemaProperties?: SchemaProperties,
-  typedContextProperties?: SchemaProperties
+  baseSchema?: Schema,
 ) {
-  const properties = chain(Object.entries(schema.properties || []))
-    .filter(([propertyName]) => !isPropertyNameDeprecated(propertyName))
-    .filter(([propertyName]) => typeof schema?.alias_for === "object" && schema.alias_for.id === "Task" ?
-      !doesPropertyExistInSchema(typedContextProperties, propertyName) :
-      !doesPropertyExistInSchema(baseSchemaProperties, propertyName))
-    .orderBy(([propertyName]) => propertyName, 'asc')
-    .value();
+  const allProperties = getAllNormalizedSchemaProperties(schema, baseSchema);
 
-  for(const [propertyName, value] of properties) {
-    const type = getTypeOfSchemaProperty(schema, propertyName, value);
-    if (!type) {
-      typescriptEmitter.appendError(
-        `No type or $ref defined for property ${propertyName} in schema ${schema.id}`
-      );
-      continue;
-    }
-
-    const isImmutable = schema.immutable?.includes(propertyName) || schema.computed?.includes(propertyName);
+  for(const property of allProperties) {
+    const isImmutable = schema.immutable?.includes(property.name) || schema.computed?.includes(property.name);
     if (isImmutable) {
       typescriptEmitter.appendBlock("readonly");
     }
 
-    typescriptEmitter.appendInline(propertyName);
+    typescriptEmitter.appendInline(property.name);
 
     const isRequired =
-      schema.required?.includes(propertyName) || schema.primary_key?.includes(propertyName);
+      schema.required?.includes(property.name) || schema.primary_key?.includes(property.name);
     if (!isRequired) {
       typescriptEmitter.appendInline("?");
     }
-
-    typescriptEmitter.appendInline(`: ${type}; `);
+    
+    typescriptEmitter.appendInline(`: ${property.typescriptType}; `);
   }
 }
 
-function getTypeOfSchemaProperty(schema: Schema, propertyName: string, value: TypedSchemaProperty | RefSchemaProperty) {
-  if(propertyName === "custom_attributes") {
-    if (isSchemaTypedContext(schema)) {
-      return "Array<TypedContextCustomAttributesMap[K]>";
-    } else {
-      return `Array<TypedContextCustomAttributesMap["${schema.id}"]>`;
-    }
-  }
-
+//TODO: maybe NormalizedSchemaProperty could already contain this standardized property format in it, so that this function wouldn't have to be called
+function getTypeOfNormalizedSchemaProperty(property: TypedSchemaProperty | RefSchemaProperty) {
   let type;
-  if ("$ref" in value && value.$ref) {
-    type = value.$ref;
-  } else if ("type" in value && value.type) {
-    type = convertTypeToTsType(propertyName, value);
-  }
-
-  /**
-  Hack to get around the fact that the API doesn't return the correct type for BasicLink
-  Task: 95e02be2-c7ec-11ed-ae64-46416ff77027
-  */
-  if (propertyName === "link" && type === "string") {
-    return "BasicLink[]";
+  if ("$ref" in property && property.$ref) {
+    type = property.$ref;
+  } else if ("type" in property && property.type) {
+    type = convertNormalizedSchemaPropertyToTypeScriptType(property);
   }
 
   return type;
 }
 
-function convertTypeToTsType(key: string, value: TypedSchemaProperty): string {
+function getOverriddenSchemaType(schema?: Schema, baseSchema?: Schema|undefined): OverriddenType {
+  if(!schema) {
+    return {};
+  }
+
+  const entityTypeMapKeyName = isSchemaTypedContext(schema) ? "K" : `"${schema.id}"`;
+
+  if(schema.id === "Type" || schema.id === "ObjectType") {
+    return {
+      genericArguments: ["K = string"],
+      properties: [
+        { name: "name", typescriptType: "K" }
+      ]
+    }
+  }
+
+  const globalPropertiesForBaseSchema = getGlobalPropertiesForSchema(baseSchema);
+
+  const overriddenPropertiesFromBaseSchema = (getOverriddenSchemaType(baseSchema).properties || [])
+    .filter(property => 
+      doesPropertyExistInSchema(schema.properties, property.name));
+
+  const propertiesToOmit = [
+    ...globalPropertiesForBaseSchema,
+    ...overriddenPropertiesFromBaseSchema
+  ];
+  
+  if(isSchemaTypedContext(schema)) {
+    return {
+      name: "TypedContextForSubtype",
+      genericArguments: ["K extends TypedContextSubtype"],
+      extends: propertiesToOmit.length > 0 ? 
+        `Omit<Context, "${propertiesToOmit.map(x => x.name).join('" | "')}">` :
+        undefined,
+      properties: [
+        { name: "custom_attributes", typescriptType: `Array<TypedContextCustomAttributesMap[${entityTypeMapKeyName}]>` },
+        { name: "type", typescriptType: `TypeFor<${entityTypeMapKeyName}>` },
+        { name: "object_type", typescriptType: `ObjectTypeFor<${entityTypeMapKeyName}>` },
+      ]
+    };
+  }
+
+  return {
+    name: schema?.id,
+    extends: propertiesToOmit.length > 0 ? 
+      `Omit<${baseSchema?.id}, "${propertiesToOmit.map(x => x.name).join('" | "')}">` : 
+      undefined,
+    properties: [
+      { name: "custom_attributes", typescriptType: `Array<TypedContextCustomAttributesMap[${entityTypeMapKeyName}]>` },
+      { name: "type", typescriptType: `TypeFor<${entityTypeMapKeyName}>` },
+      { name: "object_type", typescriptType: `ObjectTypeFor<${entityTypeMapKeyName}>` },
+    ]
+  };
+}
+
+function convertNormalizedSchemaPropertyToTypeScriptType(property: TypedSchemaProperty | RefSchemaProperty): string {
+  if('$ref' in property) {
+    return property.$ref;
+  }
+
   // Fix some types that are not supported by TypeScript
-  if (value.type === "integer") {
+  if (property.type === "integer") {
     return "number";
   }
 
-  if (value.type === "variable") {
+  if (property.type === "variable") {
     return "string | number | boolean | string[]"; // Or maybe string?
   }
 
   // If the type is an array, we need to check if the items are a built in type or a reference
-  if (value.type === "array" || value.type === "mapped_array") {
-    if (!value.items) {
-      throw new Error(`No items defined for array ${key}`);
+  if (property.type === "array" || property.type === "mapped_array") {
+    if (!property.items) {
+      throw new Error(`No items defined for array ${property.alias_for}`);
     }
 
-    if (value.items.$ref) {
-      return `${value.items.$ref}[]`;
+    if (property.items.$ref) {
+      return `${property.items.$ref}[]`;
     }
   }
 
-  return value.type;
+  return property.type;
 }
 
 function doesPropertyExistInSchema(typedContextProperties: SchemaProperties | undefined, propertyName: string) {
@@ -200,5 +188,60 @@ function doesPropertyExistInSchema(typedContextProperties: SchemaProperties | un
 }
 
 function isPropertyNameDeprecated(propertyName: string) {
-  return propertyName.startsWith("_");
+  return propertyName.startsWith("_") && !propertyName.startsWith("__");
+}
+
+function getAllNormalizedSchemaProperties(schema: Schema, baseSchema?: Schema): NormalizedSchemaProperty[] {
+  const baseSchemaProperties = baseSchema ? getAllNormalizedSchemaProperties(baseSchema) : [];
+  
+  const schemaProperties = Object
+    .entries(schema.properties || [])
+    .map(([propertyName, property]) => ({
+      name: propertyName,
+      typescriptType: convertNormalizedSchemaPropertyToTypeScriptType(property)
+    } as NormalizedSchemaProperty));
+
+  const propertiesIncludingFromBase = [...baseSchemaProperties, ...schemaProperties];
+
+  const overridenProperties = (getOverriddenSchemaType(schema).properties || [])
+    .filter(property => propertiesIncludingFromBase
+      .some(overriddenProperty => overriddenProperty.name === property.name));
+
+  const globalProperties = getGlobalPropertiesForSchema(schema);
+
+  return chain([
+    ...globalProperties,
+    ...overridenProperties,
+    ...schemaProperties,
+  ])
+    .filter(property => !isPropertyNameDeprecated(property.name))
+    .filter(property => !doesPropertyExistInSchema(baseSchema?.properties, property.name))
+    .orderBy(property => property.name)
+    .uniqBy(x => x.name)
+    .value();
+}
+
+type OverriddenType = {
+  genericArguments?: string[],
+  name?: string,
+  properties?: NormalizedSchemaProperty[],
+  extends?: string
+}
+
+type NormalizedSchemaProperty = {
+  name: string,
+  typescriptType: string
+}
+
+function getGlobalPropertiesForSchema(schema: Schema | undefined) {
+  if(!schema) {
+    return [];
+  }
+
+  const entityTypeMapKeyName = isSchemaTypedContext(schema) ? "K" : `"${schema.id}"`;
+  const globalProperties: NormalizedSchemaProperty[] = [
+    { name: "__entity_type__", typescriptType: entityTypeMapKeyName },
+    { name: "__permissions", typescriptType: "Record<string, any>" },
+  ];
+  return globalProperties;
 }

--- a/source/emitSchema.ts
+++ b/source/emitSchema.ts
@@ -23,32 +23,38 @@ export async function emitSchemaInterface(
     return;
   }
 
-  const baseSchema = isSchemaSubtypeOfTypedContext(schema) ?
-    allSchemas.find(isSchemaTypedContext) :
-    getBaseSchema(schema, allSchemas);
+  const baseSchema = isSchemaSubtypeOfTypedContext(schema)
+    ? allSchemas.find(isSchemaTypedContext)
+    : getBaseSchema(schema, allSchemas);
 
   const overriddenSchemaType = getOverriddenSchemaType(schema, baseSchema);
-  typescriptEmitter.appendBlock(`export interface ${overriddenSchemaType.name ?? schema.id}`);
+  typescriptEmitter.appendBlock(
+    `export interface ${overriddenSchemaType.name ?? schema.id}`
+  );
 
-  typescriptEmitter.appendBlock(overriddenSchemaType.genericArguments ? 
-    `<${overriddenSchemaType.genericArguments.join(", ")}>` : 
-    "");
-    
-  typescriptEmitter.appendBlock(overriddenSchemaType.extends ? `extends ${overriddenSchemaType.extends}` : "");
+  typescriptEmitter.appendBlock(
+    overriddenSchemaType.genericArguments
+      ? `<${overriddenSchemaType.genericArguments.join(", ")}>`
+      : ""
+  );
+
+  typescriptEmitter.appendBlock(
+    overriddenSchemaType.extends
+      ? `extends ${overriddenSchemaType.extends}`
+      : ""
+  );
 
   typescriptEmitter.appendBlock(`{`);
 
-  emitTypeProperties(
-    typescriptEmitter,
-    schema,
-    baseSchema
-  );
+  emitTypeProperties(typescriptEmitter, schema, baseSchema);
 
   typescriptEmitter.appendBlock(`}`);
 }
 
 function isSchemaSubtypeOfTypedContext(schema: Schema) {
-  return typeof schema?.alias_for === "object" && schema.alias_for.id === "Task";
+  return (
+    typeof schema?.alias_for === "object" && schema.alias_for.id === "Task"
+  );
 }
 
 //Todo: update when Schema type in API is updated
@@ -66,12 +72,14 @@ function getBaseSchema(schema: Schema, allSchemas: QuerySchemasResponse) {
 function emitTypeProperties(
   typescriptEmitter: TypeScriptEmitter,
   schema: Schema,
-  baseSchema?: Schema,
+  baseSchema?: Schema
 ) {
   const allProperties = getAllNormalizedSchemaProperties(schema, baseSchema);
 
-  for(const property of allProperties) {
-    const isImmutable = schema.immutable?.includes(property.name) || schema.computed?.includes(property.name);
+  for (const property of allProperties) {
+    const isImmutable =
+      schema.immutable?.includes(property.name) ||
+      schema.computed?.includes(property.name);
     if (isImmutable) {
       typescriptEmitter.appendBlock("readonly");
     }
@@ -79,17 +87,20 @@ function emitTypeProperties(
     typescriptEmitter.appendInline(property.name);
 
     const isRequired =
-      schema.required?.includes(property.name) || schema.primary_key?.includes(property.name);
+      schema.required?.includes(property.name) ||
+      schema.primary_key?.includes(property.name);
     if (!isRequired) {
       typescriptEmitter.appendInline("?");
     }
-    
+
     typescriptEmitter.appendInline(`: ${property.typescriptType}; `);
   }
 }
 
 //TODO: maybe NormalizedSchemaProperty could already contain this standardized property format in it, so that this function wouldn't have to be called
-function getTypeOfNormalizedSchemaProperty(property: TypedSchemaProperty | RefSchemaProperty) {
+function getTypeOfNormalizedSchemaProperty(
+  property: TypedSchemaProperty | RefSchemaProperty
+) {
   let type;
   if ("$ref" in property && property.$ref) {
     type = property.$ref;
@@ -100,51 +111,76 @@ function getTypeOfNormalizedSchemaProperty(property: TypedSchemaProperty | RefSc
   return type;
 }
 
-function getOverriddenSchemaType(schema?: Schema, baseSchema?: Schema|undefined): OverriddenType {
-  if(!schema) {
+function getOverriddenSchemaType(
+  schema?: Schema,
+  baseSchema?: Schema | undefined
+): OverriddenType {
+  if (!schema) {
     return {};
   }
 
-  const globalPropertiesForBaseSchema = getGlobalPropertiesForSchema(baseSchema);
+  const globalPropertiesForBaseSchema =
+    getGlobalPropertiesForSchema(baseSchema);
 
-  const overriddenPropertiesFromBaseSchema = (getOverriddenSchemaType(baseSchema).properties || [])
-    .filter(property => 
-      doesPropertyExistInSchema(schema.properties, property.name));
+  const overriddenPropertiesFromBaseSchema = (
+    getOverriddenSchemaType(baseSchema).properties || []
+  ).filter((property) =>
+    doesPropertyExistInSchema(schema.properties, property.name)
+  );
 
   const propertiesToOmit = [
     ...globalPropertiesForBaseSchema,
-    ...overriddenPropertiesFromBaseSchema
+    ...overriddenPropertiesFromBaseSchema,
   ];
-  
-  const entityTypeMapKeyName = isSchemaTypedContext(schema) ? "K" : `"${schema.id}"`;
-  if(isSchemaTypedContext(schema)) {
+
+  const entityTypeMapKeyName = isSchemaTypedContext(schema)
+    ? "K"
+    : `"${schema.id}"`;
+  if (isSchemaTypedContext(schema)) {
     return {
       name: "TypedContextForSubtype",
       genericArguments: ["K extends TypedContextSubtype"],
-      extends: propertiesToOmit.length > 0 ? 
-        `Omit<Context, "${propertiesToOmit.map(x => x.name).join('" | "')}">` :
-        undefined,
+      extends:
+        propertiesToOmit.length > 0
+          ? `Omit<Context, "${propertiesToOmit
+              .map((x) => x.name)
+              .join('" | "')}">`
+          : undefined,
       properties: [
-        { name: "custom_attributes", typescriptType: `Array<TypedContextCustomAttributesMap[${entityTypeMapKeyName}]>` },
+        {
+          name: "custom_attributes",
+          typescriptType: `Array<TypedContextCustomAttributesMap[${entityTypeMapKeyName}]>`,
+        },
         { name: "type", typescriptType: `TypeFor<${entityTypeMapKeyName}>` },
-        { name: "object_type", typescriptType: `ObjectTypeFor<${entityTypeMapKeyName}>` },
-      ]
+        {
+          name: "object_type",
+          typescriptType: `ObjectTypeFor<${entityTypeMapKeyName}>`,
+        },
+      ],
     };
   }
 
   return {
     name: schema?.id,
-    extends: propertiesToOmit.length > 0 ? 
-      `Omit<${baseSchema?.id}, "${propertiesToOmit.map(x => x.name).join('" | "')}">` : 
-      undefined,
+    extends:
+      propertiesToOmit.length > 0
+        ? `Omit<${baseSchema?.id}, "${propertiesToOmit
+            .map((x) => x.name)
+            .join('" | "')}">`
+        : undefined,
     properties: [
-      { name: "custom_attributes", typescriptType: `Array<TypedContextCustomAttributesMap[${entityTypeMapKeyName}]>` },
-    ]
+      {
+        name: "custom_attributes",
+        typescriptType: `Array<TypedContextCustomAttributesMap[${entityTypeMapKeyName}]>`,
+      },
+    ],
   };
 }
 
-function convertNormalizedSchemaPropertyToTypeScriptType(property: TypedSchemaProperty | RefSchemaProperty): string {
-  if('$ref' in property) {
+function convertNormalizedSchemaPropertyToTypeScriptType(
+  property: TypedSchemaProperty | RefSchemaProperty
+): string {
+  if ("$ref" in property) {
     return property.$ref;
   }
 
@@ -171,7 +207,10 @@ function convertNormalizedSchemaPropertyToTypeScriptType(property: TypedSchemaPr
   return property.type;
 }
 
-function doesPropertyExistInSchema(typedContextProperties: SchemaProperties | undefined, propertyName: string) {
+function doesPropertyExistInSchema(
+  typedContextProperties: SchemaProperties | undefined,
+  propertyName: string
+) {
   return typedContextProperties?.[propertyName];
 }
 
@@ -179,21 +218,35 @@ function isPropertyNameDeprecated(propertyName: string) {
   return propertyName.startsWith("_") && !propertyName.startsWith("__");
 }
 
-function getAllNormalizedSchemaProperties(schema: Schema, baseSchema?: Schema): NormalizedSchemaProperty[] {
-  const baseSchemaProperties = baseSchema ? getAllNormalizedSchemaProperties(baseSchema) : [];
-  
-  const schemaProperties = Object
-    .entries(schema.properties || [])
-    .map(([propertyName, property]) => ({
-      name: propertyName,
-      typescriptType: convertNormalizedSchemaPropertyToTypeScriptType(property)
-    } as NormalizedSchemaProperty));
+function getAllNormalizedSchemaProperties(
+  schema: Schema,
+  baseSchema?: Schema
+): NormalizedSchemaProperty[] {
+  const baseSchemaProperties = baseSchema
+    ? getAllNormalizedSchemaProperties(baseSchema)
+    : [];
 
-  const propertiesIncludingFromBase = [...baseSchemaProperties, ...schemaProperties];
+  const schemaProperties = Object.entries(schema.properties || []).map(
+    ([propertyName, property]) =>
+      ({
+        name: propertyName,
+        typescriptType:
+          convertNormalizedSchemaPropertyToTypeScriptType(property),
+      } as NormalizedSchemaProperty)
+  );
 
-  const overridenProperties = (getOverriddenSchemaType(schema).properties || [])
-    .filter(property => propertiesIncludingFromBase
-      .some(overriddenProperty => overriddenProperty.name === property.name));
+  const propertiesIncludingFromBase = [
+    ...baseSchemaProperties,
+    ...schemaProperties,
+  ];
+
+  const overridenProperties = (
+    getOverriddenSchemaType(schema).properties || []
+  ).filter((property) =>
+    propertiesIncludingFromBase.some(
+      (overriddenProperty) => overriddenProperty.name === property.name
+    )
+  );
 
   const globalProperties = getGlobalPropertiesForSchema(schema);
 
@@ -202,31 +255,36 @@ function getAllNormalizedSchemaProperties(schema: Schema, baseSchema?: Schema): 
     ...overridenProperties,
     ...schemaProperties,
   ])
-    .filter(property => !isPropertyNameDeprecated(property.name))
-    .filter(property => !doesPropertyExistInSchema(baseSchema?.properties, property.name))
-    .orderBy(property => property.name)
-    .uniqBy(x => x.name)
+    .filter((property) => !isPropertyNameDeprecated(property.name))
+    .filter(
+      (property) =>
+        !doesPropertyExistInSchema(baseSchema?.properties, property.name)
+    )
+    .orderBy((property) => property.name)
+    .uniqBy((x) => x.name)
     .value();
 }
 
 type OverriddenType = {
-  genericArguments?: string[],
-  name?: string,
-  properties?: NormalizedSchemaProperty[],
-  extends?: string
-}
+  genericArguments?: string[];
+  name?: string;
+  properties?: NormalizedSchemaProperty[];
+  extends?: string;
+};
 
 type NormalizedSchemaProperty = {
-  name: string,
-  typescriptType: string
-}
+  name: string;
+  typescriptType: string;
+};
 
 function getGlobalPropertiesForSchema(schema: Schema | undefined) {
-  if(!schema) {
+  if (!schema) {
     return [];
   }
 
-  const entityTypeMapKeyName = isSchemaTypedContext(schema) ? "K" : `"${schema.id}"`;
+  const entityTypeMapKeyName = isSchemaTypedContext(schema)
+    ? "K"
+    : `"${schema.id}"`;
   const globalProperties: NormalizedSchemaProperty[] = [
     { name: "__entity_type__", typescriptType: entityTypeMapKeyName },
     { name: "__permissions", typescriptType: "Record<string, any>" },

--- a/source/emitSchema.ts
+++ b/source/emitSchema.ts
@@ -105,17 +105,6 @@ function getOverriddenSchemaType(schema?: Schema, baseSchema?: Schema|undefined)
     return {};
   }
 
-  const entityTypeMapKeyName = isSchemaTypedContext(schema) ? "K" : `"${schema.id}"`;
-
-  if(schema.id === "Type" || schema.id === "ObjectType") {
-    return {
-      genericArguments: ["K = string"],
-      properties: [
-        { name: "name", typescriptType: "K" }
-      ]
-    }
-  }
-
   const globalPropertiesForBaseSchema = getGlobalPropertiesForSchema(baseSchema);
 
   const overriddenPropertiesFromBaseSchema = (getOverriddenSchemaType(baseSchema).properties || [])
@@ -127,6 +116,7 @@ function getOverriddenSchemaType(schema?: Schema, baseSchema?: Schema|undefined)
     ...overriddenPropertiesFromBaseSchema
   ];
   
+  const entityTypeMapKeyName = isSchemaTypedContext(schema) ? "K" : `"${schema.id}"`;
   if(isSchemaTypedContext(schema)) {
     return {
       name: "TypedContextForSubtype",
@@ -150,7 +140,6 @@ function getOverriddenSchemaType(schema?: Schema, baseSchema?: Schema|undefined)
     properties: [
       { name: "custom_attributes", typescriptType: `Array<TypedContextCustomAttributesMap[${entityTypeMapKeyName}]>` },
       { name: "type", typescriptType: `TypeFor<${entityTypeMapKeyName}>` },
-      { name: "object_type", typescriptType: `ObjectTypeFor<${entityTypeMapKeyName}>` },
     ]
   };
 }

--- a/source/emitSchema.ts
+++ b/source/emitSchema.ts
@@ -97,20 +97,6 @@ function emitTypeProperties(
   }
 }
 
-//TODO: maybe NormalizedSchemaProperty could already contain this standardized property format in it, so that this function wouldn't have to be called
-function getTypeOfNormalizedSchemaProperty(
-  property: TypedSchemaProperty | RefSchemaProperty
-) {
-  let type;
-  if ("$ref" in property && property.$ref) {
-    type = property.$ref;
-  } else if ("type" in property && property.type) {
-    type = convertNormalizedSchemaPropertyToTypeScriptType(property);
-  }
-
-  return type;
-}
-
 function getOverriddenSchemaType(
   schema?: Schema,
   baseSchema?: Schema | undefined

--- a/source/typescriptEmitter.ts
+++ b/source/typescriptEmitter.ts
@@ -13,9 +13,13 @@ export class TypeScriptEmitter {
     this._errors = [];
   }
 
-  public appendCode(text: string) {
-    this._code += ` ${text} `;
+  public appendInline(text: string) {
+    this._code += text;
     return this;
+  }
+
+  public appendBlock(text: string) {
+    return this.appendInline(` ${text} `);
   }
 
   public appendError(message: string) {


### PR DESCRIPTION
<!--
  [For internal use] 
  Copy the task id from the bottom of the sidebar and paste it after FTRACK-

  Resolves FTRACK-

-->

- [x] I have added automatic tests where applicable
- [x] The PR title is suitable as a release note
- [x] The PR contains a description of what has been changed
- [x] The description contains manual test instructions

## Changes
This PR makes type and object type properties of entities strong-typed. This makes it very nice when building up queries that involve checking the type name.

It also refactors some of the code to be (in my opinion) cleaner. It is now easier to see in one place how various overrides to the types are being made. This increases the cohesion of the code quite heavily.

## Test
N/A
