### PR TITLE
chore(deps): upgrade @ftrack/api + make it runnable without esbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prepublish": "yarn test"
   },
   "dependencies": {
-    "@ftrack/api": "^1.4.5",
+    "@ftrack/api": "^1.11.3-rc.1",
     "prettier": "^3.5.3"
   },
   "files": [
@@ -33,7 +33,6 @@
   "devDependencies": {
     "@eslint/js": "^9.22.0",
     "@types/node": "^22.13.10",
-    "@types/ws": "^8.18.0",
     "@typescript-eslint/utils": "^8.26.1",
     "@vitest/eslint-plugin": "^1.1.37",
     "esbuild": "^0.25.1",

--- a/source/emit.test.ts
+++ b/source/emit.test.ts
@@ -6,11 +6,19 @@ import {
   type Status,
   type Type,
   emitToString,
-} from "./emit";
-import type { QuerySchemasResponse, Schema } from "@ftrack/api";
+} from "./emit.ts";
+import type { Schema as ApiSchema } from "./session.ts";
+import { type QuerySchemasResponse, type Schema } from "@ftrack/api";
 import { readFile } from "fs/promises";
 import { join } from "path";
-import type { CustomAttributeConfiguration } from "./emitCustomAttributes";
+import type { CustomAttributeConfiguration } from "./emitCustomAttributes.ts";
+
+vi.mock("@ftrack/api", (importOriginal) => {
+  return {
+    ...importOriginal,
+    Session: class Session {},
+  };
+});
 
 beforeEach(() => {
   vi.setSystemTime(new Date(2023, 1, 1, 0, 0, 0));
@@ -50,7 +58,7 @@ test("schema subtype of TypedContext", async () => {
   const emitResult = await emitToString(
     "4.13.8",
     "https://ftrack.example.com",
-    schemas as QuerySchemasResponse,
+    schemas as QuerySchemasResponse<ApiSchema>,
     [],
     [],
     [],
@@ -84,7 +92,7 @@ test("schema has base schema", async () => {
   const emitResult = await emitToString(
     "4.13.8",
     "https://ftrack.example.com",
-    schemas as QuerySchemasResponse,
+    schemas as QuerySchemasResponse<ApiSchema>,
     [],
     [],
     [],
@@ -119,7 +127,7 @@ test("schema has immutable property", async () => {
   const emitResult = await emitToString(
     "4.13.8",
     "https://ftrack.example.com",
-    schemas as QuerySchemasResponse,
+    schemas as QuerySchemasResponse<ApiSchema>,
     [],
     [],
     [],
@@ -153,7 +161,7 @@ test("schema has integer type", async () => {
   const emitResult = await emitToString(
     "4.13.8",
     "https://ftrack.example.com",
-    schemas as QuerySchemasResponse,
+    schemas as QuerySchemasResponse<ApiSchema>,
     [],
     [],
     [],
@@ -187,7 +195,7 @@ test("schema has variable type", async () => {
   const emitResult = await emitToString(
     "4.13.8",
     "https://ftrack.example.com",
-    schemas as QuerySchemasResponse,
+    schemas as QuerySchemasResponse<ApiSchema>,
     [],
     [],
     [],
@@ -234,7 +242,7 @@ test("schema has array type", async () => {
   const emitResult = await emitToString(
     "4.13.8",
     "https://ftrack.example.com",
-    schemas as QuerySchemasResponse,
+    schemas as QuerySchemasResponse<ApiSchema>,
     [],
     [],
     [],
@@ -262,7 +270,7 @@ test("default highway test (all values specified)", async () => {
     ),
   );
 
-  const schemas = await parseJsonFromFile<Schema[]>(
+  const schemas = await parseJsonFromFile<QuerySchemasResponse<ApiSchema>>(
     join(".", "source", "__snapshots__", "responses", "query_schemas.json"),
   );
 

--- a/source/emitCustomAttributes.ts
+++ b/source/emitCustomAttributes.ts
@@ -1,5 +1,6 @@
 import type { QuerySchemasResponse } from "@ftrack/api";
-import { TypeScriptEmitter } from "./typescriptEmitter";
+import { TypeScriptEmitter } from "./typescriptEmitter.ts";
+import type { Schema } from "./session.ts";
 
 const uniq = <T>(array: T[]): T[] => {
   return Array.from(new Set(array));
@@ -21,7 +22,7 @@ const groupBy = <T, K extends string>(list: T[], getKey: (item: T) => K) => {
 
 export function emitCustomAttributes(
   typescriptEmitter: TypeScriptEmitter,
-  schemas: QuerySchemasResponse,
+  schemas: QuerySchemasResponse<Schema>,
   customAttributes: CustomAttributeConfiguration[],
 ) {
   typescriptEmitter.appendCode(`

--- a/source/emitSchema.ts
+++ b/source/emitSchema.ts
@@ -1,18 +1,19 @@
 // :copyright: Copyright (c) 2023 ftrack
 import type {
   QuerySchemasResponse,
-  Schema,
   SchemaProperties,
   TypedSchemaProperty,
+  Schema,
 } from "@ftrack/api";
-import { type TypeScriptEmitter } from "./typescriptEmitter";
-import { isSchemaTypedContext } from "./utils";
+import { type TypeScriptEmitter } from "./typescriptEmitter.ts";
+import { isSchemaTypedContext } from "./utils.ts";
+import type { Schema as ApiSchema } from "./session.ts";
 
 // Add schemas from the schemas folder, to be used for finding extended schemas
 export async function emitSchemaInterface(
   typescriptEmitter: TypeScriptEmitter,
   schema: Schema,
-  allSchemas: QuerySchemasResponse,
+  allSchemas: QuerySchemasResponse<ApiSchema>,
 ) {
   const interfaceName = getTypeScriptInterfaceNameForInterface(schema);
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,23 +1,10 @@
 #!/usr/bin/env node
 // :copyright: Copyright (c) 2023 ftrack
-// A node.js script to convert our query_schema to TypeScript types
-// TODO: Change type to module in API
-import { Session } from "@ftrack/api";
-import { emitToFile } from "./emit";
-
-const session = new Session(
-  process.env.FTRACK_SERVER ?? "",
-  process.env.FTRACK_API_USER ?? "",
-  process.env.FTRACK_API_KEY ?? "",
-);
+import { emitToFile } from "./emit.ts";
 
 const outputPath = process.argv[2] || "__generated__";
 const outputFilename = process.argv[3] || "schema.ts";
-const { errors, schemas } = await emitToFile(
-  session,
-  outputPath,
-  outputFilename,
-);
+const { errors, schemas } = await emitToFile(outputPath, outputFilename);
 
 console.info(`${schemas.length} schema(s) found`);
 

--- a/source/session.ts
+++ b/source/session.ts
@@ -1,0 +1,27 @@
+import { Session } from "@ftrack/api";
+import type {
+  ObjectType,
+  Type,
+  Priority,
+  ProjectSchema,
+  Status,
+} from "./emit.ts";
+import type { CustomAttributeConfiguration } from "./emitCustomAttributes.ts";
+
+export interface Schema {
+  ObjectType: ObjectType;
+  CustomAttributeConfiguration: CustomAttributeConfiguration;
+  Type: Type;
+  Priority: Priority;
+  ProjectSchema: ProjectSchema;
+  Status: Status;
+}
+
+export const session = new Session<Schema>(
+  process.env.FTRACK_SERVER ?? "",
+  process.env.FTRACK_API_USER ?? "",
+  process.env.FTRACK_API_KEY ?? "",
+  {
+    autoConnectEventHub: false,
+  },
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,7 @@
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
     "isolatedModules": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
+    "module": "NodeNext",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "noEmit": true,
     "resolveJsonModule": true,
@@ -15,7 +14,8 @@
     "target": "ESNext",
     "useDefineForClassFields": true,
     "verbatimModuleSyntax": true,
-    "erasableSyntaxOnly": true
+    "erasableSyntaxOnly": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["source/**/*.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -266,14 +266,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ftrack/api@npm:^1.4.5":
-  version: 1.4.6
-  resolution: "@ftrack/api@npm:1.4.6"
+"@ftrack/api@npm:^1.11.3-rc.1":
+  version: 1.11.3-rc.1
+  resolution: "@ftrack/api@npm:1.11.3-rc.1"
   dependencies:
-    loglevel: "npm:^1.8.1"
-    moment: "npm:^2.29.4"
-    uuid: "npm:^9.0.0"
-  checksum: 10/4ead504a04a8b367dfd4961af1c3b337d731c9fbdf5844601a29a53c39ec8945ec6bca00d4a91c8f41a6f96e242d43b4a40782c2d95344619175ad05fdec3515
+    loglevel: "npm:^1.9.2"
+    moment: "npm:^2.30.1"
+    uuid: "npm:^11.1.0"
+  peerDependencies:
+    ws: ^8.13.0
+  peerDependenciesMeta:
+    ws:
+      optional: true
+  checksum: 10/090c079cd2177a4dbd857211069ac038adb2b346e7584658de7a069f803fde93ee516aa1123e12f57db6ca1c3a2db09339e1298e4b5996a6543770bdf1513f48
   languageName: node
   linkType: hard
 
@@ -282,9 +287,8 @@ __metadata:
   resolution: "@ftrack/ts-schema-generator@workspace:."
   dependencies:
     "@eslint/js": "npm:^9.22.0"
-    "@ftrack/api": "npm:^1.4.5"
+    "@ftrack/api": "npm:^1.11.3-rc.1"
     "@types/node": "npm:^22.13.10"
-    "@types/ws": "npm:^8.18.0"
     "@typescript-eslint/utils": "npm:^8.26.1"
     "@vitest/eslint-plugin": "npm:^1.1.37"
     esbuild: "npm:^0.25.1"
@@ -563,21 +567,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^22.13.10":
+"@types/node@npm:^22.13.10":
   version: 22.13.10
   resolution: "@types/node@npm:22.13.10"
   dependencies:
     undici-types: "npm:~6.20.0"
   checksum: 10/57dc6a5e0110ca9edea8d7047082e649fa7fa813f79e4a901653b9174141c622f4336435648baced5b38d9f39843f404fa2d8d7a10981610da26066bc8caab48
-  languageName: node
-  linkType: hard
-
-"@types/ws@npm:^8.18.0":
-  version: 8.18.0
-  resolution: "@types/ws@npm:8.18.0"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10/2a3bbf27690532627bfde8a215c0cf3a56680f339f972785b30d0b4665528275b9270c0a0839244610b0a3f2da4218c6dd741ceba1d173fde5c5091f2034b823
   languageName: node
   linkType: hard
 
@@ -1950,10 +1945,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loglevel@npm:^1.8.1":
-  version: 1.8.1
-  resolution: "loglevel@npm:1.8.1"
-  checksum: 10/36a786082a7e4f1d962de330122291da3a102b88dbde81a45eb92a045c38b0903783958ba39dce641440c0413da303410e7f2565f897bccad828853bd5974c86
+"loglevel@npm:^1.9.2":
+  version: 1.9.2
+  resolution: "loglevel@npm:1.9.2"
+  checksum: 10/6153d8db308323f7ee20130bc40309e7a976c30a10379d8666b596d9c6441965c3e074c8d7ee3347fe5cfc059c0375b6f3e8a10b93d5b813cc5547f5aa412a29
   languageName: node
   linkType: hard
 
@@ -2150,10 +2145,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moment@npm:^2.29.4":
-  version: 2.29.4
-  resolution: "moment@npm:2.29.4"
-  checksum: 10/157c5af5a0ba8196e577bc67feb583303191d21ba1f7f2af30b3b40d4c63a64d505ba402be2a1454832082fac6be69db1e0d186c3279dae191e6634b0c33705c
+"moment@npm:^2.30.1":
+  version: 2.30.1
+  resolution: "moment@npm:2.30.1"
+  checksum: 10/ae42d876d4ec831ef66110bdc302c0657c664991e45cf2afffc4b0f6cd6d251dde11375c982a5c0564ccc0fa593fc564576ddceb8c8845e87c15f58aa6baca69
   languageName: node
   linkType: hard
 
@@ -2889,12 +2884,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "uuid@npm:9.0.0"
+"uuid@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "uuid@npm:11.1.0"
   bin:
-    uuid: dist/bin/uuid
-  checksum: 10/23857699a616d1b48224bc2b8440eae6e57d25463c3a0200e514ba8279dfa3bde7e92ea056122237839cfa32045e57d8f8f4a30e581d720fd72935572853ae2e
+    uuid: dist/esm/bin/uuid
+  checksum: 10/d2da43b49b154d154574891ced66d0c83fc70caaad87e043400cf644423b067542d6f3eb641b7c819224a7cd3b4c2f21906acbedd6ec9c6a05887aa9115a9cf5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
  [For internal use] 
  Copy the task id from the bottom of the sidebar and paste it after FTRACK-

  Resolves FTRACK-

-->

- [ ] I have added automatic tests where applicable
- [ ] The PR title is suitable as a release note
- [ ] The PR contains a description of what has been changed
- [ ] The description contains manual test instructions

## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

- Upgrades @ftrack/api to latest, with the new typescript schema setup.
- Fix imports to import ts files to enable running this with `node --experimental-strip-types` rather than through esbuild.

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
